### PR TITLE
Fix alarm states after update to HA 2024.11.0

### DIFF
--- a/custom_components/jablotron_cloud/binary_sensor.py
+++ b/custom_components/jablotron_cloud/binary_sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
         if not gates_data:
             continue
 
-        gates = gates_data["programmableGates"]
+        gates = gates_data.get("programmableGates", [])
         for gate in gates:
             can_control = gate["can-control"]
             if can_control:

--- a/custom_components/jablotron_cloud/const.py
+++ b/custom_components/jablotron_cloud/const.py
@@ -1,6 +1,6 @@
 """Constants for the Jablotron Cloud integration."""
 
-from homeassistant.backports.enum import StrEnum
+from enum import StrEnum
 
 DOMAIN = "jablotron_cloud"
 

--- a/custom_components/jablotron_cloud/sensor.py
+++ b/custom_components/jablotron_cloud/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -63,7 +63,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity):
     """Representation of Jablotron temperature sensor."""
 
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
         if not gates_data:
             continue
 
-        gates = gates_data["programmableGates"]
+        gates = gates_data.get("programmableGates", [])
         for gate in gates:
             can_control = gate["can-control"]
             if not can_control:

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Zařízení je už nakonfigurované"
+            "already_configured": "Zařízení je již nakonfigurováno"
         },
         "error": {
             "cannot_connect": "Není možné se připojit",
             "invalid_auth": "Nesprávné přihlašovací údaje",
-            "unknown": "Neočakávaná chyba"
+            "unknown": "Neočekávaná chyba"
         },
         "step": {
             "user": {
                 "data": {
                     "pin": "PIN",
                     "password": "Heslo",
-                    "username": "Přihlašovací jméno"
+                    "username": "Uživatelské jméno"
                 }
             }
         }


### PR DESCRIPTION
As I described in #30, hassio apparently made a breaking change and this integration stopped reporting alarm entity states correctly. This PR fixes setting entity states, including changing deprecated parts of the code to the current one.

**Changes made:**
 - changed attribute `_attr_state` to `_attr_alarm_state`
 - changed `STATE_ALARM_*` constants to `AlarmControlPanelState`
 - changed unit of degrees to type `UnitOfTemperature`
 - replaced deprecated `StrEnum` with current one
 - fixed KeyError when no PGs are available
 - improved Czech translation

Fixes #30