### PR TITLE
feat: add list of services without PG

### DIFF
--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, SERVICE_ID, SERVICE_TYPE
+from .const import DOMAIN, SERVICE_ID, SERVICE_TYPE, SERVICES_WITHOUT_PG
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,10 +131,10 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                 service_type = service[SERVICE_TYPE]
 
                 _LOGGER.debug("Loading data for service %d", service_id)
-                if service_type == 'LOGBOOK':
+                if service_type in SERVICES_WITHOUT_PG:
                     _LOGGER.debug("Service type %s not supported. Skipping service %d", service_type, service_id)
                     continue
-                
+
                 try:
                     gates = await self.hass.async_add_executor_job(
                         self.bridge.get_programmable_gates, service_id, service_type
@@ -143,7 +143,7 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                     self.api_fail_count += 1
                     _LOGGER.debug(f"Failed to get gates data for service {service_id}")
                     raise UpdateFailed(f"Failed to get gates data for service {service_id}") from error
-            
+
                 try:
                     sections = await self.hass.async_add_executor_job(
                         self.bridge.get_sections, service_id, service_type
@@ -162,7 +162,7 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                     _LOGGER.debug(f"Failed to get thermo data for service {service_id}")
                     raise UpdateFailed(f"Failed to get thermo data for service {service_id}") from error
 
-                
+
                 data[service_id] = {}
                 data[service_id]["service"] = service
                 data[service_id]["gates"] = gates
@@ -175,4 +175,3 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
 
             self.is_first_update = False            
             return data
-

--- a/custom_components/jablotron_cloud/const.py
+++ b/custom_components/jablotron_cloud/const.py
@@ -12,6 +12,7 @@ DEVICE_ID = "object-device-id"
 PG_STATE = "state"
 PG_STATE_OFF = "OFF"
 
+SERVICES_WITHOUT_PG = ["FUTURA2", "AMBIENTA", "VOLTA", "LOGBOOK"]
 
 class Actions(StrEnum):
     """Actions to control sections."""


### PR DESCRIPTION
Hi @Pigotka,

Thanks for this project!

This PR should solve also following issues: https://github.com/Pigotka/ha-cc-jablotron-cloud/issues/28, https://github.com/Pigotka/ha-cc-jablotron-cloud/issues/23 and https://github.com/Pigotka/ha-cc-jablotron-cloud/issues/24

I have multiple jablotron services installed in my house - VOLTA, FUTURA2 and AMBIENTA and none from the listed services have PG's. Take a look at the following code and its results in my case:

```python
import os
from jablotronpy.jablotronpy import Jablotron

j = Jablotron(username=os.environ["JABLOTRON_USER"],
              password=os.environ["JABLOTRON_PASS"],
              pin_code=os.environ["JABLOTRON_PIN"])

print("getting services")
for service in j.get_services():
    print("Service: ", service["service-type"])

    try:
        print("Getting PG's...")
        for device in j.get_programmable_gates(service["service-id"], service["service-type"]):
            print("Got PG")
            print(device)
    except Exception as e:
        print("PG service error ", service["service-type"], " ", e)
```

It outputs:

```log
getting services
Service:  FUTURA2
Getting PG's...
  An unexpected error occurred, status code: 404, response: {'http-code': 404, 'errors': [{'code': 'FUNCTION.NOT-FOUND', 'message': ''}], 'meta': {'display-type': 'TOAST'}, 'sentry-error-id': 'b48a05c1964841d89c718a6c910ac1d4'}, {"http-code":404,"errors":[{"code":"FUNCTION.NOT-FOUND","message":""}],"meta":{"display-type":"TOAST"},"sentry-error-id":"b48a05c1964841d89c718a6c910ac1d4"}
  PG service error  FUTURA2   'dict' object has no attribute 'json'

Service:  JA100F
Getting PG's...
  Got PG
  service-states
  Got PG
  states
  Got PG
  programmableGates

Service:  VOLTA
Getting PG's...
  An unexpected error occurred, status code: 404, response: {'http-code': 404, 'errors': [{'code': 'FUNCTION.NOT-FOUND', 'message': ''}], 'meta': {'display-type': 'TOAST'}, 'sentry-error-id': '15373243451c46f3b9abe60efc2a6f7b'}, {"http-code":404,"errors":[{"code":"FUNCTION.NOT-FOUND","message":""}],"meta":{"display-type":"TOAST"},"sentry-error-id":"15373243451c46f3b9abe60efc2a6f7b"}
  PG service error  VOLTA   'dict' object has no attribute 'json'

Service:  AMBIENTA
Getting PG's...
  An unexpected error occurred, status code: 404, response: {'http-code': 404, 'errors': [{'code': 'FUNCTION.NOT-FOUND', 'message': ''}], 'meta': {'display-type': 'TOAST'}, 'sentry-error-id': '88ad8d6151804753a3badeec8571adfc'}, {"http-code":404,"errors":[{"code":"FUNCTION.NOT-FOUND","message":""}],"meta":{"display-type":"TOAST"},"sentry-error-id":"88ad8d6151804753a3badeec8571adfc"}
  PG service error  AMBIENTA   'dict' object has no attribute 'json'
```