### PR TITLE
Integration rewrite and QoL improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+indent_size = 2
+
+[*.json]
+indent_size = 4
+
+[*.py]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDEs and editors
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@
 
 ![Jablotron logo](https://github.com/Pigotka/ha-cc-jablotron-cloud/blob/main/logo.png)
 
-
 # Jablotron Cloud
 
-HACS custom component for jablotron cloud integration
-
+HACS custom component for Jablotron cloud integration
 
 ## About
 
-Integration works with MyJablotron web service available on https://www.jablonet.net/. It uses mobile API provided by [JablotronPy](https://github.com/fdegier/JablotronPy) library. It does not have full capabilities of web interface and some function are not yet supported by the integration. See the list of supported function below.
+Integration works with MyJablotron web service available on https://www.jablonet.net/. It uses mobile API provided
+by [JablotronPy](https://github.com/fdegier/JablotronPy) library. It does not have full capabilities of web interface
+and some function are not yet supported by the integration. See the list of supported function below.
 
 **This component will set up the following platforms.**
 
-| Platform         | Description                         |
-| ---------------- | ----------------------------------- |
-| `binary_sensor`| To show uncontrollable programmable gates (PG) .   |
-| `switch`| To controll programmable gates (PG) .   |
-| `alarm_control_panel`| To enable ARM/DISARM on individual sections. |
-| `sensor`| To support temperature and electricity sensors. |
+| Platform              | Description                                     |
+|-----------------------|-------------------------------------------------|
+| `binary_sensor`       | To show uncontrollable programmable gates (PGs) |
+| `switch`              | To control programmable gates (PGs)             |
+| `alarm_control_panel` | To enable ARM/DISARM on individual sections     |
+| `sensor`              | To support temperature and electricity sensors  |
 
 ## HACS Installation
 
@@ -46,18 +46,24 @@ Integration works with MyJablotron web service available on https://www.jablonet
 
 To configure integration please fill credentials you use to access your MyJablotron web page or mobile app.
 
-**Following fields needs to be filled:**
+**The configuration consists of the following parameters:**
 
-| Field         | Description                         |
-| ---------------- | ----------------------------------- |
-| `username` | Email associated with Jablotron cloud.   |
-| `password` | Password use to login into the webpage. |
+| Field      | Description                                         |
+|------------|-----------------------------------------------------|
+| `username` | Email associated with Jablotron Cloud account       |
+| `password` | Password for Jablotron Cloud account                |
+| `pin`      | Default pin used **ONLY** to control PGs (optional) |
 
 ## Supported functionality
 
-1. Programmable gates - show status of every programmable gate in your system. PG can be created to signal any state you like by your Jablotron provider. It can indicate you for example that section is armed or that it is armed only partially. It can also tell you state of you garage door or window contact sensors. Most of PG's can be controlled to trigger some Jablotron action.
-2. Sections - every section is individual alarm control panel as it requires PIN codes to control it and can be ARMED (Armed Away) or PARTIALLY ARMED (Armed Home). Section also support friendly names defined in you cloud installation.
-3. Default pin code - it can be configured in alarm entity options. Once configured code will become optional parameter for arm service.
+1. Programmable gates - show status of every programmable gate in your system. PG can be created to signal any state you
+   like by your Jablotron provider. It can indicate you for example that section is armed or that it is armed only
+   partially. It can also tell you state of you garage door or window contact sensors. Most of PG's can be controlled to
+   trigger some Jablotron action.
+2. Sections - every section is individual alarm control panel as it requires PIN codes to control it and can be ARMED (
+   Armed Away) or PARTIALLY ARMED (Armed Home). Section also support friendly names defined in you cloud installation.
+3. Default pin code - it can be configured in alarm entity options. Once configured code will become optional parameter
+   for arm service.
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -1,83 +1,75 @@
-![Home_Assistant](https://img.shields.io/badge/Home-Assistant-blue)
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-![GitHub](https://img.shields.io/github/license/viktak/ha-cc-openweathermap_all)
+![Home Assistant](https://img.shields.io/badge/Home-Assistant-blue?style=for-the-badge)
+![HACS](https://img.shields.io/badge/HACS-Integration-blue?style=for-the-badge)
+![GitHub license](https://img.shields.io/github/license/Pigotka/ha-cc-jablotron-cloud?style=for-the-badge)
 
-[![buy me a coffee](https://img.shields.io/badge/If%20you%20like%20it-Buy%20us%20a%20coffee-green.svg?style=for-the-badge)](https://www.buymeacoffee.com/michalbartP)
+[![Buy me a coffee](https://img.shields.io/badge/buy_me_a_coffee-orange?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white)](https://www.buymeacoffee.com/michalbartP)
+
+---
 
 ![Jablotron logo](https://github.com/Pigotka/ha-cc-jablotron-cloud/blob/main/logo.png)
 
 # Jablotron Cloud
 
-HACS custom component for Jablotron cloud integration
+Home Assistant custom component for Jablotron Cloud.
 
 ## About
 
-Integration works with MyJablotron web service available on https://www.jablonet.net/. It uses mobile API provided
-by [JablotronPy](https://github.com/fdegier/JablotronPy) library. It does not have full capabilities of web interface
-and some function are not yet supported by the integration. See the list of supported function below.
+This integration allows you to monitor and control alarm sections as well as programmable gates and temperature sensors.
+It does not require a direct connection to the alarm control panel to run, instead it uses a cloud connection via
+MyJablotron and takes advantage of the mobile API provided by the [JablotronPy](https://github.com/fdegier/JablotronPy)
+library.
 
-**This component will set up the following platforms.**
+## Supported entities
 
-| Platform              | Description                                     |
-|-----------------------|-------------------------------------------------|
-| `binary_sensor`       | To show uncontrollable programmable gates (PGs) |
-| `switch`              | To control programmable gates (PGs)             |
-| `alarm_control_panel` | To enable ARM/DISARM on individual sections     |
-| `sensor`              | To support temperature and electricity sensors  |
+The integration uses the following entities to enable monitoring and control of individual components of the Jablotron
+ecosystem:
+
+| Entity type           | Description                                                     |
+|-----------------------|-----------------------------------------------------------------|
+| `alarm_control_panel` | Used for monitoring and controlling alarm sections              |
+| `binary_sensor`       | Used for monitoring **UN**controllable programmable gates (PGs) |
+| `switch`              | Used for controlling programmable gates (PGs)                   |
+| `sensor`              | Used for monitoring temperature sensors                         |
 
 ## HACS Installation
 
-1. Add repository using "+Explore & download repositories" button in HACS inside integrations section
-2. Search for Jablotron Cloud in HACS
-3. Install
-4. In HA add new integration and select Jablotron Cloud.
+This integration can be installed using HACS, this can be achieved as follows:
+
+1. Install and open HACS in Home Assistant
+2. Search for `Jablotron Cloud`
+3. Open it and click on `Download` button
+4. In Home Assistant go to Integrations
+5. Click on `Add integration` button
+6. Search for `Jablotron Cloud`
+7. Complete configuration and confirm
 
 ## Manual Installation
 
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-3. In the `custom_components` directory (folder) create a new folder called `jablotron_cloud`.
-4. Download _all_ the files from the `custom_components/jablotron_cloud/` directory (folder) in this repository.
-5. Place the files you downloaded in the new directory (folder) you created.
+If you are not using HACS, you can install this integration manually as follows:
+
+1. Open Home Assistant installation configuration directory (you should see `configuration.yaml` file)
+2. Create `custom_components` folder, or skip this step if already exists
+3. Open `custom_components` folder
+4. Download `custom_components/jablotron_cloud` folder from this repository
+5. Place downloaded `jablotron_cloud` folder to created `custom_components` folder
 6. Restart Home Assistant
-7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Jablotron Cloud"
+7. In Home Assistant go to Integrations
+8. Click on `Add integration` button
+9. Search for `Jablotron Cloud`
+10. Complete configuration and confirm
 
-## Configuration is done in the UI
+## Integration configuration
 
-To configure integration please fill credentials you use to access your MyJablotron web page or mobile app.
+To successfully set up this integration, you will need the username (email) and password used for the MyJablotron web
+service/mobile app.
 
-**The configuration consists of the following parameters:**
+The integration allows you to modify the following parameters:
 
-| Field      | Description                                         |
-|------------|-----------------------------------------------------|
-| `username` | Email associated with Jablotron Cloud account       |
-| `password` | Password for Jablotron Cloud account                |
-| `pin`      | Default pin used **ONLY** to control PGs (optional) |
+* Default pin used to control PGs
+* Whether to bypass section errors by default when arming sections
+* Frequency of polling data from Jablotron Cloud
+* Timeout for polling data from Jablotron Cloud
 
-## Supported functionality
+## Missing functionality
 
-1. Programmable gates - show status of every programmable gate in your system. PG can be created to signal any state you
-   like by your Jablotron provider. It can indicate you for example that section is armed or that it is armed only
-   partially. It can also tell you state of you garage door or window contact sensors. Most of PG's can be controlled to
-   trigger some Jablotron action.
-2. Sections - every section is individual alarm control panel as it requires PIN codes to control it and can be ARMED (
-   Armed Away) or PARTIALLY ARMED (Armed Home). Section also support friendly names defined in you cloud installation.
-3. Default pin code - it can be configured in alarm entity options. Once configured code will become optional parameter
-   for arm service.
-
-## Known issues
-
-1. Data are updated only every 30s
-2. Arming and disarming has no delay to leave the house.
-3. First entity get it's real state ony after 30s. Then it works like any other entity.
-4. Integration does not listen for active alarms
-5. Arming is always with FORCE param overriding any periphery error. This should be converted into user option.
-
-## Missing functionality - will be added
-
-1. Impulse counters
-2. Alarm event detection
-
-# Support
-
-![Jablotron logo](https://github.com/Pigotka/ha-cc-jablotron-cloud/blob/main/bmc_qr.png)
+* Integration does not listen for active alarms **- this is limitation of Jablotron Cloud API**

--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -1,177 +1,230 @@
-"""The Jablotron Cloud integration."""
+"""Jablotron Cloud integration."""
+
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
-
-import async_timeout
-from jablotronpy import Jablotron, UnexpectedResponse
+from asyncio import timeout
+from dataclasses import dataclass
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_PIN, CONF_FORCE_UPDATE, CONF_SCAN_INTERVAL, \
+    CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from jablotronpy import Jablotron, UnauthorizedException
 
-from .const import DOMAIN, SERVICE_ID, SERVICE_TYPE, SERVICES_WITHOUT_PG
+from .const import PLATFORMS, UNSUPPORTED_SERVICES
+from .jablotron import JablotronClient
+from .types import JablotronServiceData
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [
-    Platform.ALARM_CONTROL_PANEL,
-    Platform.BINARY_SENSOR,
-    Platform.SWITCH,
-    Platform.SENSOR,
-]
+type JablotronConfigEntry = ConfigEntry[JablotronData]
 
-ASYNC_TIMEOUT = 120
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Jablotron Cloud from a config entry."""
+async def async_setup_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
+    """Set up Jablotron Cloud from config entry."""
 
-    username = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]    
+    _LOGGER.debug("Preparing Jablotron API client")
+    username: str = entry.data[CONF_USERNAME]
+    password: str = entry.data[CONF_PASSWORD]
+    default_pin: str = entry.data[CONF_PIN]
+    force_arm: bool = entry.data[CONF_FORCE_UPDATE]
+    client = JablotronClient(username, password, default_pin, force_arm)
 
     _LOGGER.debug("Preparing Jablotron data update coordinator")
+    scan_interval: int = entry.data[CONF_SCAN_INTERVAL]
+    scan_timeout: int = entry.data[CONF_TIMEOUT]
+    coordinator = JablotronDataCoordinator(hass, client, scan_interval, scan_timeout)
 
-    bridge = Jablotron(username, password, "")
-    coordinator = JablotronDataCoordinator(hass, bridge)
+    # Prepare runtime data
+    entry.runtime_data = JablotronData(client, coordinator)
 
+    # Fetch initial data for platforms initialization
     await coordinator.async_config_entry_first_refresh()
 
+    # Listen for configuration changes
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
+    # Setup all supported platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
+    """Unload Jablotron Cloud integration."""
 
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update listener."""
+async def update_listener(hass: HomeAssistant, entry: JablotronConfigEntry) -> None:
+    """Handle configuration changes."""
+
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-class JablotronDataCoordinator(DataUpdateCoordinator):
-    """Data coordinator around jablotron cloud API."""
+async def async_migrate_entry(hass: HomeAssistant, config_entry: JablotronConfigEntry) -> bool:
+    """Handle migration of config entry data."""
 
-    def __init__(self, hass, bridge):
-        """Initialize coordinator."""
+    # Get current config version
+    version = config_entry.version
+    minor_version = config_entry.minor_version
+
+    # Ignore that user downgraded from newer version of integration
+    if version > 3:
+        return False
+
+    # Modify config entry based on previous version
+    _LOGGER.debug("Migrating configuration from version %s.%s", version, minor_version)
+    new_data = config_entry.data.copy()
+    if version == 2:
+        # Add default values for 'force_update', 'scan_interval' and 'timeout'
+        new_data[CONF_FORCE_UPDATE] = True
+        new_data[CONF_SCAN_INTERVAL] = 30
+        new_data[CONF_TIMEOUT] = 15
+
+    # Set config entry version to the latest one
+    hass.config_entries.async_update_entry(config_entry, data=new_data, minor_version=1, version=3)
+    _LOGGER.info("Migrated configuration to version %s.%s", config_entry.version, config_entry.minor_version)
+
+    return True
+
+
+@dataclass
+class JablotronData:
+    """Integration runtime data."""
+
+    client: JablotronClient
+    coordinator: JablotronDataCoordinator
+
+
+class JablotronDataCoordinator(DataUpdateCoordinator):
+    """Data coordinator for Jablotron Cloud integration."""
+
+    def __init__(self, hass: HomeAssistant, client: JablotronClient, scan_interval: int, scan_timeout: int) -> None:
+        """Initialize Home Assistant data update coordinator."""
+
+        # Define coordinator attributes
+        self._client = client
+        self._scan_timeout = scan_timeout
+
+        # Initialize data update coordinator
         super().__init__(
             hass,
             _LOGGER,
             name="Jablotron Cloud",
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=scan_interval)
         )
-        self.bridge = bridge
-        self.is_first_update = True
-        self.api_fail_count = 0
 
-    async def _recreate_bridge(self):
-        # recreate bridge to restart connection until it is fixed on bridge side
-        self.bridge = Jablotron(self.bridge.username, self.bridge.password, self.bridge.pin_code)
-        _LOGGER.warning("Bridge recreated.")
+    async def _async_setup(self) -> None:
+        """Fetch initial data for all platforms."""
 
-    async def _async_update_data(self):
-        """Fetch data from API endpoint.
+        try:
+            # Get available services from Jablotron Cloud
+            _LOGGER.debug("Discovering available Jablotron services")
+            bridge: Jablotron = await self.hass.async_add_executor_job(self._client.get_bridge)  # noqa
+            services = await self.hass.async_add_executor_job(bridge.get_services)  # noqa
 
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
-        data = {}
-        # Note: asyncio.TimeoutError and aiohttp.ClientError are already
-        # handled by the data update coordinator.
-        async with async_timeout.timeout(ASYNC_TIMEOUT):                        
-
-            # API is failing, try to recreate session
-            if self.api_fail_count > 0:
-                try:
-                    session_id = await self.hass.async_add_executor_job(
-                        self.bridge.get_session_id
-                    )
-                except UnexpectedResponse as error:
-                    _LOGGER.debug("Unable to get session id.")
-                    await self._recreate_bridge()
-                    raise UpdateFailed("Unable to get session ID. JablotronPy bridge recreated.") from error
-
-                if not session_id:
-                    _LOGGER.debug("Invalid session id.")
-                    await self._recreate_bridge()
-                    return
-
-                # session is valid reset fail counter and continue
-                self.api_fail_count = 0
-
-            services = None
-            try:
-                services = await self.hass.async_add_executor_job(
-                    self.bridge.get_services
-                )
-            except UnexpectedResponse as error:
-                self.api_fail_count += 1
-                _LOGGER.debug("Failed to get services!")
-                raise UpdateFailed("Failed to get services!") from error
-
+            # Log that no services were discovered
             if not services:
-                _LOGGER.info("No services discovered for this jablotron account. No entities will be generated.")
-                return data
+                _LOGGER.warning("No services were discovered and therefore no entities will be generated!")
 
+            # Get all available platforms and their states for each service
             for service in services:
-                service_id = service[SERVICE_ID]
-                service_type = service[SERVICE_TYPE]
+                # Get service details
+                service_name = service["name"]
+                service_id = service["service-id"]
+                service_type = service["service-type"]
 
-                _LOGGER.debug("Loading data for service %d", service_id)
-                if service_type in SERVICES_WITHOUT_PG:
-                    _LOGGER.debug("Service type %s not supported. Skipping service %d", service_type, service_id)
+                # Check whether service type is supported
+                if service_type in UNSUPPORTED_SERVICES:
+                    _LOGGER.debug("Service '%s' is not supported, ignoring!", service_type)
+
                     continue
 
-                try:
-                    gates = await self.hass.async_add_executor_job(
-                        self.bridge.get_programmable_gates, service_id, service_type
+                # Initialize service data
+                self._client.services[service_id] = JablotronServiceData(name=service_name, type=service_type)  # noqa
+
+                # Get additional service data
+                _LOGGER.debug("Fetching additional data for service '%d'", service_id)
+                self._client.services[service_id]["firmware"] = (await self.hass.async_add_executor_job(
+                    bridge.get_service_information,
+                    service_id
+                )).get("device", {}).get("firmware", "N/A")
+
+                # Get available sections from Jablotron Cloud
+                _LOGGER.debug("Discovering available sections for service '%d'", service_id)
+                self._client.services[service_id]["alarm"] = await self.hass.async_add_executor_job(
+                    bridge.get_sections,
+                    service_id,
+                    service_type
+                )
+
+                # Get available gates from Jablotron Cloud
+                _LOGGER.debug("Discovering available gates for service '%d'", service_id)
+                self._client.services[service_id]["gates"] = await self.hass.async_add_executor_job(
+                    bridge.get_programmable_gates,
+                    service_id,
+                    service_type
+                )
+
+                # Get available thermo devices from Jablotron Cloud
+                _LOGGER.debug("Discovering available thermo devices for service '%d'", service_id)
+                self._client.services[service_id]["thermo"] = await self.hass.async_add_executor_job(
+                    bridge.get_thermo_devices,
+                    service_id,
+                    service_type
+                )
+
+                _LOGGER.debug("Successfully discovered available platforms for service '%d'", service_id)
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+
+    async def _async_update_data(self) -> None:
+        """Update data for all platforms."""
+
+        try:
+            # Update data within a certain time limit
+            async with timeout(self._scan_timeout):
+                # Get fresh Jablotron Cloud session
+                _LOGGER.debug("Updating data for available Jablotron services")
+                bridge: Jablotron = await self.hass.async_add_executor_job(self._client.get_bridge)  # noqa
+
+                # Update data for all available services
+                for service_id in self._client.services:
+                    # Get service details
+                    service_type = self._client.services[service_id]["type"]
+
+                    # Update sections data from Jablotron Cloud
+                    _LOGGER.debug("Updating sections data for service '%d'", service_id)
+                    self._client.services[service_id]["alarm"] = await self.hass.async_add_executor_job(
+                        bridge.get_sections,
+                        service_id,
+                        service_type
                     )
-                except UnexpectedResponse as error:
-                    self.api_fail_count += 1
-                    _LOGGER.debug(f"Failed to get gates data for service {service_id}")
-                    raise UpdateFailed(f"Failed to get gates data for service {service_id}") from error
 
-                try:
-                    sections = await self.hass.async_add_executor_job(
-                        self.bridge.get_sections, service_id, service_type
+                    # Update gates data from Jablotron Cloud
+                    _LOGGER.debug("Updating gates data for service '%d'", service_id)
+                    self._client.services[service_id]["gates"] = await self.hass.async_add_executor_job(
+                        bridge.get_programmable_gates,
+                        service_id,
+                        service_type
                     )
-                except UnexpectedResponse as error:                    
-                    self.api_fail_count += 1
-                    _LOGGER.debug(f"Failed to get section data for service {service_id}")
-                    raise UpdateFailed(f"Failed to get section data for service {service_id}") from error                                        
 
-                try:
-                    thermo_devices = await self.hass.async_add_executor_job(
-                        self.bridge.get_thermo_devices, service_id, service_type
+                    # Update thermo devices data from Jablotron Cloud
+                    _LOGGER.debug("Updating thermo devices data for service '%d'", service_id)
+                    self._client.services[service_id]["thermo"] = await self.hass.async_add_executor_job(
+                        bridge.get_thermo_devices,
+                        service_id,
+                        service_type
                     )
-                except UnexpectedResponse as error:
-                    self.api_fail_count += 1
-                    _LOGGER.debug(f"Failed to get thermo data for service {service_id}")
-                    raise UpdateFailed(f"Failed to get thermo data for service {service_id}") from error
 
-
-                data[service_id] = {}
-                data[service_id]["service"] = service
-                data[service_id]["gates"] = gates
-                data[service_id]["sections"] = sections
-                data[service_id]["thermo"] = thermo_devices
-
-                _LOGGER.debug("Service %d successfuly updated.", service_id)
-                if self.is_first_update:                    
-                    _LOGGER.debug("Service %d discovered. Data: %s", service_id, str(data[service_id]))
-
-            self.is_first_update = False            
-            return data
+                    _LOGGER.debug("Successfully updated platforms data for service '%d'", service_id)
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except TimeoutError:
+            # Warn that timeout occurred that will cause data to not be up-to-date
+            _LOGGER.warning("Timeout while updating data for available services, data may be out of date!")

--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -8,8 +8,14 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_PIN, CONF_FORCE_UPDATE, CONF_SCAN_INTERVAL, \
+from homeassistant.const import (
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_PIN,
+    CONF_FORCE_UPDATE,
+    CONF_SCAN_INTERVAL,
     CONF_TIMEOUT
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.entity_registry import async_migrate_entries

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity, AlarmControlPanelEntityFeature, \
-    AlarmControlPanelState, CodeFormat
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+    CodeFormat
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -1,208 +1,280 @@
 """Support for Jablotron alarm control panels."""
+
 from __future__ import annotations
 
 import logging
 
-from homeassistant.components.alarm_control_panel import (
-    AlarmControlPanelEntity,
-    AlarmControlPanelEntityFeature,
-    CodeFormat, AlarmControlPanelState,
-)
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity, AlarmControlPanelEntityFeature, \
+    AlarmControlPanelState, CodeFormat
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from jablotronpy import UnauthorizedException, IncorrectPinCodeException
 
-from . import JablotronDataCoordinator
-from .const import COMP_ID, DOMAIN, SERVICE_TYPE, Actions
+from . import JablotronConfigEntry, JablotronData, JablotronDataCoordinator, JablotronClient
+from .const import DOMAIN
+from .utils import get_component_state, section_state_to_alarm_state
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,  # noqa: F841
+    entry: JablotronConfigEntry,
+    async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up alarm panel from Jablotron Cloud from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    services = coordinator.data
-    entities = []
+    """Register alarm panel entity for each Jablotron service section."""
 
-    if not services:
-        return
+    _LOGGER.debug("Adding Jablotron alarm control panel entities")
+    runtime_data: JablotronData = entry.runtime_data
+    coordinator = runtime_data.coordinator
+    client = runtime_data.client
 
-    for service_id, service_data in services.items():
-        service = service_data["service"]
-        _LOGGER.debug(
-            "Jablotron discovered service: %s:%s", service_id, service["name"]
-        )
+    # Get sections for each service
+    entities: list[JablotronAlarmControlPanel] = []
+    for service_id, service_data in client.services.items():
+        # Get service details
+        service_name = service_data["name"]
+        service_type = service_data["type"]
+        service_firmware = service_data["firmware"]
 
-        sections_data = service_data["sections"]
-        if not sections_data:
-            _LOGGER.debug(
-                "Jablotron sections date are empty, skipping service: %s:%s", service_id, service["name"]
-            )
-            continue
+        # Add all controllable section entities
+        _LOGGER.debug("Getting available sections for service '%s'", service_name)
+        alarm = service_data["alarm"]
+        for section in alarm["sections"]:
+            # Get section details
+            section_name = section["name"]
+            section_id = section["cloud-component-id"]
+            partial_arm_enabled = section["partial-arm-enabled"]
+            requires_authorization = section["need-authorization"]
+            section_state = get_component_state(section_id, alarm["states"])
+            current_state = section_state_to_alarm_state(section_state)
 
-        sections = sections_data["sections"]
-        if not sections:
-            _LOGGER.debug(
-                "Jablotron section date are empty, skipping service: %s:%s", service_id, service["name"]
-            )
-            continue
+            # Check whether section is controllable
+            if not section["can-control"]:
+                _LOGGER.debug("Section '%s' is not controllable, ignoring!", section_name)
 
-        for section in sections:
-            can_control = section["can-control"]
-            if can_control:
-                friendly_name = section["name"]
-                component_id = section[COMP_ID]
-                partial_arm_enabled = bool(section["partial-arm-enabled"])
-                need_authorization = bool(section["need-authorization"])
-                _LOGGER.debug("Controllable section discovered: %s", friendly_name)
-                entities.append(
-                    JablotronAlarmControlPanel(
-                        coordinator,
-                        service_id,
-                        component_id,
-                        partial_arm_enabled,
-                        need_authorization,
-                        friendly_name,
-                    )
+                continue
+
+            # Add controllable section entity
+            _LOGGER.debug("Adding controllable section '%s'", section_name)
+            entities.append(
+                JablotronAlarmControlPanel(
+                    coordinator,
+                    client,
+                    service_id,
+                    service_name,
+                    service_type,
+                    service_firmware,
+                    section_id,
+                    section_name,
+                    partial_arm_enabled,
+                    requires_authorization,
+                    current_state
                 )
+            )
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:  # noqa: F841
+    """Unload alarm panel entities."""
+
     return True
 
 
-class JablotronAlarmControlPanel(
-    CoordinatorEntity[JablotronDataCoordinator],
-    AlarmControlPanelEntity,
-):
-    """Representation of a Jablotron cloud based alarm panel."""
+class JablotronAlarmControlPanel(CoordinatorEntity[JablotronDataCoordinator], AlarmControlPanelEntity):
+    """Representation of Jablotron Cloud alarm panel entity."""
 
+    # Allow custom entity names
     _attr_has_entity_name = True
-
-    _actions_to_state_alarm = {
-        Actions.ARM: AlarmControlPanelState.ARMED_AWAY,
-        Actions.DISARM: AlarmControlPanelState.DISARMED,
-        Actions.PARTIAL_ARM: AlarmControlPanelState.ARMED_HOME,
-    }
 
     def __init__(
         self: JablotronAlarmControlPanel,
         coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
-        component_id: str,
+        service_name: str,
+        service_type: str,
+        service_firmware: str,
+        section_id: str,
+        section_name: str,
         partial_arm_enabled: bool,
-        need_authorization: bool,
-        friendly_name: str,
+        requires_authorization: bool,
+        current_state: AlarmControlPanelState
     ) -> None:
         """Initialize Jablotron alarm panel."""
-        super().__init__(coordinator)
+
+        # Define entity attributes
+        self._client = client
         self._service_id = service_id
-        self._component_id = component_id
-        self._can_partial_arm = partial_arm_enabled
-        self._need_authorization = need_authorization
-        self._attr_unique_id = f"{service_id} {component_id}"
-        self._attr_name = friendly_name        
-        self._service_type = self.coordinator.data[service_id]["service"][SERVICE_TYPE]
+        self._service_name = service_name
+        self._service_type = service_type
+        self._service_firmware = service_firmware
+        self._section_id = section_id
+        self._section_name = section_name
+
+        # Define panel attributes
+        self._attr_name = section_name
+        self._attr_unique_id = f"{service_id}_{section_id}"
+        self._supports_partial_arm = partial_arm_enabled
+        self._authorization_required = requires_authorization
+        self._attr_alarm_state = current_state
+
+        # Initialize alarm control panel
+        super().__init__(coordinator)
 
     @property
     def code_format(self) -> CodeFormat | None:
         """Disable code for sections that don't require it."""
-        return CodeFormat.NUMBER if self.code_arm_required else None
+
+        return CodeFormat.NUMBER if self._authorization_required else None
 
     @property
     def code_arm_required(self) -> bool:
-        """Whether the code is required for arm actions."""
-        return self._need_authorization
+        """Whether code is required for arm actions."""
+
+        return self._authorization_required
 
     @property
     def supported_features(self) -> AlarmControlPanelEntityFeature:
-        """Return the list of supported features."""
-        if self._can_partial_arm:
-            return (
-                AlarmControlPanelEntityFeature.ARM_AWAY
-                | AlarmControlPanelEntityFeature.ARM_HOME
-            )
+        """Return list of supported features."""
 
-        return AlarmControlPanelEntityFeature.ARM_AWAY
+        supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+        if self._supports_partial_arm:
+            supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
+
+        return supported_features
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return the device info."""
+        """Return information about device."""
+
         return DeviceInfo(
-            identifiers={
-                # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, str(self._service_id))
-            },
-            name=self.coordinator.data[self._service_id]["service"]["name"],
+            identifiers={(DOMAIN, str(self._service_id))},
+            name=self._service_name,
             manufacturer="Jablotron",
-            model=self.coordinator.data[self._service_id]["service"][SERVICE_TYPE],
+            model=self._service_type,
+            sw_version=self._service_firmware
         )
 
     def alarm_disarm(self, code: str | None = None) -> None:
-        """Disarm section."""
-        self._setup_pin(code)
+        """Send disarm request."""
 
-        self.coordinator.bridge.control_component(
-            self._service_id, self._component_id, Actions.DISARM, self._service_type
-        )
-        self._attr_alarm_state = AlarmControlPanelState.DISARMING
-        self.schedule_update_ha_state()
+        try:
+            # Send disarm request to section
+            code = self.code_or_default_code(code)
+            bridge = self._client.get_bridge()
+            disarm_successful = bridge.control_section(
+                service_id=self._service_id,
+                service_type=self._service_type,
+                component_id=self._section_id,
+                state="DISARM",
+                pin_code=code
+            )
+
+            # Set state to disarming if disarm action was successful
+            if disarm_successful:
+                self._attr_alarm_state = AlarmControlPanelState.DISARMING
+                self.schedule_update_ha_state()
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except IncorrectPinCodeException:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_pin"
+            )
 
     def alarm_arm_away(self, code: str | None = None) -> None:
-        """Arm section."""
-        self._setup_pin(code)
+        """Send arm request."""
 
-        self.coordinator.bridge.control_component(
-            self._service_id, self._component_id, Actions.ARM, self._service_type, force=True
-        )
-        self._attr_alarm_state = AlarmControlPanelState.ARMING
-        self.schedule_update_ha_state()
+        try:
+            # Send arm request to section
+            code = self.code_or_default_code(code)
+            bridge = self._client.get_bridge()
+            arm_successful = bridge.control_section(
+                service_id=self._service_id,
+                service_type=self._service_type,
+                component_id=self._section_id,
+                state="ARM",
+                pin_code=code,
+                force=self._client.force_arm
+            )
+
+            # Set state to arming if arm action was successful
+            if arm_successful:
+                self._attr_alarm_state = AlarmControlPanelState.ARMING
+                self.schedule_update_ha_state()
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except IncorrectPinCodeException:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_pin"
+            )
 
     def alarm_arm_home(self, code: str | None = None) -> None:
-        """Partial arm section if allowed."""
-        if not self._can_partial_arm:
-            _LOGGER.error("This action should not be available for this section")
+        """Send partial arm request."""
+
+        # Check that partial arm is supported
+        if not self._supports_partial_arm:
             return
 
-        self._setup_pin(code)
-        self.coordinator.bridge.control_component(
-            self._service_id,
-            self._component_id,
-            Actions.PARTIAL_ARM,
-            self._service_type,
-            force=True
-        )
-        self._attr_alarm_state = AlarmControlPanelState.ARMING
-        self.schedule_update_ha_state()
+        try:
+            # Send partial arm request to section
+            code = self.code_or_default_code(code)
+            bridge = self._client.get_bridge()
+            arm_successful = bridge.control_section(
+                service_id=self._service_id,
+                service_type=self._service_type,
+                component_id=self._section_id,
+                state="PARTIAL_ARM",
+                pin_code=code,
+                force=self._client.force_arm
+            )
 
-    def _setup_pin(self, code: str | None) -> None:
-        self.coordinator.bridge.pin_code = self.code_or_default_code(code)
+            # Set state to arming if partial arm action was successful
+            if arm_successful:
+                self._attr_alarm_state = AlarmControlPanelState.ARMING
+                self.schedule_update_ha_state()
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except IncorrectPinCodeException:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_pin"
+            )
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        if not self.coordinator.data or self._service_id not in self.coordinator.data:
-            _LOGGER.error("Invalid section data. Maybe session expired")
+        """Process data retrieved by coordinator."""
+
+        # Get corresponding service data
+        _LOGGER.debug("Updating alarm state for section '%s'", self._section_name)
+        service = self._client.services.get(self._service_id, None)
+        if not service:
+            _LOGGER.error("No data available for service '%d'!", self._service_id)
+
             return
 
-        sections_data = self.coordinator.data[self._service_id].get("sections", {})
-        states = sections_data.get("states", [])
-        if not states:
-            _LOGGER.warning("States data not found")
+        # Get service states
+        service_states = service["alarm"]["states"]
+        if not service_states:
+            _LOGGER.warning("No states data available for service '%d'!", self._service_id)
+
             return
 
-        state = next(filter(lambda data: data[COMP_ID] == self._component_id, states))
-        _LOGGER.debug("Updating section state: %s", str(state))
-        self._attr_alarm_state = self._actions_to_state_alarm.get(
-            state["state"], AlarmControlPanelState.DISARMED
-        )
-        self.schedule_update_ha_state()
+        # Get section state
+        section_state = get_component_state(self._section_id, service_states)
+        if not section_state:
+            _LOGGER.warning("No state available for section '%s'!", self._section_name)
+
+            return
+
+        # Set current section state
+        self._attr_alarm_state = section_state_to_alarm_state(section_state)
+        self.async_write_ha_state()
+
+        _LOGGER.debug("Successfully updated alarm state for section '%s'", self._section_name)

--- a/custom_components/jablotron_cloud/config_flow.py
+++ b/custom_components/jablotron_cloud/config_flow.py
@@ -15,23 +15,17 @@ from .jablotron import JablotronClient
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_schema(
-    username: str = "",
-    pin: str = "",
-    force_arm: bool = True,
-    scan_interval: int = 30,
-    scan_timeout: int = 15
-) -> vol.Schema:
+def get_schema(config: dict) -> vol.Schema:
     """Return config flow schema."""
 
     return vol.Schema(
         {
-            vol.Required(CONF_USERNAME, default=username): str,
+            vol.Required(CONF_USERNAME, default=config.get(CONF_USERNAME, "")): str,
             vol.Required(CONF_PASSWORD): str,
-            vol.Optional(CONF_PIN, default=pin): str,
-            vol.Optional(CONF_FORCE_UPDATE, default=force_arm): bool,
-            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): int,
-            vol.Optional(CONF_TIMEOUT, default=scan_timeout): int
+            vol.Optional(CONF_PIN, default=config.get(CONF_PIN, "")): str,
+            vol.Optional(CONF_FORCE_UPDATE, default=config.get(CONF_FORCE_UPDATE, True)): bool,
+            vol.Optional(CONF_SCAN_INTERVAL, default=config.get(CONF_SCAN_INTERVAL, 30)): int,
+            vol.Optional(CONF_TIMEOUT, default=config.get(CONF_TIMEOUT, 15)): int
         }
     )
 
@@ -56,7 +50,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Open configuration dialog
         if user_input is None:
-            return self.async_show_form(data_schema=get_schema())
+            return self.async_show_form(data_schema=get_schema({}))
 
         try:
             # Validate entered credentials and reopen dialog if they are not valid
@@ -64,13 +58,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.async_add_executor_job(validate_credentials, user_input)
         except UnauthorizedException:
             return self.async_show_form(
-                data_schema=get_schema(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PIN],
-                    user_input[CONF_FORCE_UPDATE],
-                    user_input[CONF_SCAN_INTERVAL],
-                    user_input[CONF_TIMEOUT]
-                ),
+                data_schema=get_schema(user_input),
                 errors={"base": "invalid_auth"}
             )
         else:
@@ -86,15 +74,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Open reconfiguration dialog
         # noinspection DuplicatedCode
         if user_input is None:
-            return self.async_show_form(
-                data_schema=get_schema(
-                    config_entry.data[CONF_USERNAME],
-                    config_entry.data[CONF_PIN],
-                    config_entry.data[CONF_FORCE_UPDATE],
-                    config_entry.data[CONF_SCAN_INTERVAL],
-                    config_entry.data[CONF_TIMEOUT]
-                )
-            )
+            return self.async_show_form(data_schema=get_schema(config_entry.data))
 
         try:
             # Validate entered credentials and reopen dialog if they are not valid
@@ -102,13 +82,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.async_add_executor_job(validate_credentials, user_input)
         except UnauthorizedException:
             return self.async_show_form(
-                data_schema=get_schema(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PIN],
-                    user_input[CONF_FORCE_UPDATE],
-                    user_input[CONF_SCAN_INTERVAL],
-                    user_input[CONF_TIMEOUT]
-                ),
+                data_schema=get_schema(user_input),
                 errors={"base": "invalid_auth"}
             )
         else:
@@ -135,13 +109,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="reauth_confirm",
-                data_schema=get_schema(
-                    config_entry.data[CONF_USERNAME],
-                    config_entry.data[CONF_PIN],
-                    config_entry.data[CONF_FORCE_UPDATE],
-                    config_entry.data[CONF_SCAN_INTERVAL],
-                    config_entry.data[CONF_TIMEOUT]
-                )
+                data_schema=get_schema(config_entry.data)
             )
 
         try:
@@ -151,13 +119,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except UnauthorizedException:
             return self.async_show_form(
                 step_id="reauth_confirm",
-                data_schema=get_schema(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PIN],
-                    user_input[CONF_FORCE_UPDATE],
-                    user_input[CONF_SCAN_INTERVAL],
-                    user_input[CONF_TIMEOUT]
-                ),
+                data_schema=get_schema(user_input),
                 errors={"base": "invalid_auth"}
             )
         else:

--- a/custom_components/jablotron_cloud/config_flow.py
+++ b/custom_components/jablotron_cloud/config_flow.py
@@ -1,73 +1,169 @@
 """Config flow for Jablotron Cloud integration."""
-from __future__ import annotations
 
 import logging
-from typing import Any
 
-from jablotronpy import Jablotron, UnexpectedResponse
 import voluptuous as vol
-
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_PIN, CONF_FORCE_UPDATE, CONF_SCAN_INTERVAL, \
+    CONF_TIMEOUT
+from jablotronpy import UnauthorizedException
 
 from .const import DOMAIN
+from .jablotron import JablotronClient
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
+
+def get_schema(
+    username: str = "",
+    pin: str = "",
+    force_arm: bool = True,
+    scan_interval: int = 30,
+    scan_timeout: int = 15
+) -> vol.Schema:
+    """Return config flow schema."""
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_USERNAME, default=username): str,
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_PIN, default=pin): str,
+            vol.Optional(CONF_FORCE_UPDATE, default=force_arm): bool,
+            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): int,
+            vol.Optional(CONF_TIMEOUT, default=scan_timeout): int
+        }
+    )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect."""
+def validate_credentials(user_input: dict) -> None:
+    """Validate that user entered valid credentials."""
 
-    hub = Jablotron(data[CONF_USERNAME], data[CONF_PASSWORD], "")
-    try:
-        await hass.async_add_executor_job(hub.get_session_id)
-    except UnexpectedResponse as ex:
-        raise InvalidAuth from ex
-
-    # Return info that you want to store in the config entry.
-    return {"title": "Jablotron Cloud"}
+    # Initialize Jablotron client and validate entered credentials
+    client = JablotronClient(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+    client.get_bridge()
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Jablotron Cloud."""
+    """Handle config flow for Jablotron Cloud."""
 
-    VERSION = 2
+    # Define configuration version
+    VERSION = 3
+    MINOR_VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the initial step."""
+    async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
+        """User flow to configure Jablotron Cloud integration."""
+
+        # Open configuration dialog
         if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
-
-        errors = {}
+            return self.async_show_form(data_schema=get_schema())
 
         try:
-            info = await validate_input(self.hass, user_input)
-        except InvalidAuth:
-            errors["base"] = "invalid_auth"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
+            # Validate entered credentials and reopen dialog if they are not valid
+            _LOGGER.debug("Validating Jablotron Cloud credentials")
+            await self.hass.async_add_executor_job(validate_credentials, user_input)
+        except UnauthorizedException:
+            return self.async_show_form(
+                data_schema=get_schema(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PIN],
+                    user_input[CONF_FORCE_UPDATE],
+                    user_input[CONF_SCAN_INTERVAL],
+                    user_input[CONF_TIMEOUT]
+                ),
+                errors={"base": "invalid_auth"}
+            )
         else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+            _LOGGER.info("Jablotron Cloud integration successfully configured")
+            return self.async_create_entry(title="Jablotron Cloud", data=user_input)
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-        )
+    async def async_step_reconfigure(self, user_input: dict | None = None) -> ConfigFlowResult:
+        """User flow to reconfigure Jablotron Cloud integration."""
 
+        # Get existing configuration
+        config_entry = self._get_reconfigure_entry()
 
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""
+        # Open reconfiguration dialog
+        # noinspection DuplicatedCode
+        if user_input is None:
+            return self.async_show_form(
+                data_schema=get_schema(
+                    config_entry.data[CONF_USERNAME],
+                    config_entry.data[CONF_PIN],
+                    config_entry.data[CONF_FORCE_UPDATE],
+                    config_entry.data[CONF_SCAN_INTERVAL],
+                    config_entry.data[CONF_TIMEOUT]
+                )
+            )
+
+        try:
+            # Validate entered credentials and reopen dialog if they are not valid
+            _LOGGER.debug("Validating Jablotron Cloud credentials")
+            await self.hass.async_add_executor_job(validate_credentials, user_input)
+        except UnauthorizedException:
+            return self.async_show_form(
+                data_schema=get_schema(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PIN],
+                    user_input[CONF_FORCE_UPDATE],
+                    user_input[CONF_SCAN_INTERVAL],
+                    user_input[CONF_TIMEOUT]
+                ),
+                errors={"base": "invalid_auth"}
+            )
+        else:
+            _LOGGER.info("Jablotron Cloud integration successfully reconfigured")
+            return self.async_update_reload_and_abort(
+                config_entry,
+                unique_id=config_entry.unique_id,
+                data={**config_entry.data, **user_input}
+            )
+
+    async def async_step_reauth(self, entry_data: dict | None = None) -> ConfigFlowResult:  # noqa: F841
+        """Handler for API authentication errors."""
+
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict | None = None) -> ConfigFlowResult:
+        """User flow to update credentials for Jablotron Cloud integration."""
+
+        # Get existing configuration
+        config_entry = self._get_reauth_entry()
+
+        # Open reconfiguration dialog
+        # noinspection DuplicatedCode
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=get_schema(
+                    config_entry.data[CONF_USERNAME],
+                    config_entry.data[CONF_PIN],
+                    config_entry.data[CONF_FORCE_UPDATE],
+                    config_entry.data[CONF_SCAN_INTERVAL],
+                    config_entry.data[CONF_TIMEOUT]
+                )
+            )
+
+        try:
+            # Validate entered credentials and reopen dialog if they are not valid
+            _LOGGER.debug("Validating Jablotron Cloud credentials")
+            await self.hass.async_add_executor_job(validate_credentials, user_input)
+        except UnauthorizedException:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=get_schema(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PIN],
+                    user_input[CONF_FORCE_UPDATE],
+                    user_input[CONF_SCAN_INTERVAL],
+                    user_input[CONF_TIMEOUT]
+                ),
+                errors={"base": "invalid_auth"}
+            )
+        else:
+            _LOGGER.info("Jablotron Cloud integration successfully reconfigured")
+            return self.async_update_reload_and_abort(
+                config_entry,
+                unique_id=config_entry.unique_id,
+                data={**config_entry.data, **user_input}
+            )

--- a/custom_components/jablotron_cloud/config_flow.py
+++ b/custom_components/jablotron_cloud/config_flow.py
@@ -52,7 +52,7 @@ async def handle_configuration(
         )
 
     # Validate interval value
-    if user_input[CONF_SCAN_INTERVAL] < 20:
+    if user_input[CONF_SCAN_INTERVAL] < 30:
         return self.async_show_form(  # type: ignore
             step_id=step_id,
             data_schema=get_schema(user_input),

--- a/custom_components/jablotron_cloud/config_flow.py
+++ b/custom_components/jablotron_cloud/config_flow.py
@@ -5,8 +5,14 @@ import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_PIN, CONF_FORCE_UPDATE, CONF_SCAN_INTERVAL, \
+from homeassistant.const import (
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_PIN,
+    CONF_FORCE_UPDATE,
+    CONF_SCAN_INTERVAL,
     CONF_TIMEOUT
+)
 from jablotronpy import UnauthorizedException
 
 from .const import DOMAIN

--- a/custom_components/jablotron_cloud/const.py
+++ b/custom_components/jablotron_cloud/const.py
@@ -1,22 +1,26 @@
-"""Constants for the Jablotron Cloud integration."""
+"""Constants for Jablotron Cloud integration."""
 
-from enum import StrEnum
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import Platform
 
+# Integration constants
 DOMAIN = "jablotron_cloud"
+UNSUPPORTED_SERVICES = ["FUTURA2", "AMBIENTA", "VOLTA", "LOGBOOK"]
+PLATFORMS: list[Platform] = [
+    Platform.ALARM_CONTROL_PANEL,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.SENSOR,
+]
 
-SERVICE_ID = "service-id"
-SERVICE_TYPE = "service-type"
+# Jablotron states as Home Assistant states
+SECTION_STATE_AS_ALARM_STATE = {
+    "ARM": AlarmControlPanelState.ARMED_AWAY,
+    "PARTIAL_ARM": AlarmControlPanelState.ARMED_HOME,
+    "DISARM": AlarmControlPanelState.DISARMED,
+}
 
-COMP_ID = "cloud-component-id"
-DEVICE_ID = "object-device-id"
-PG_STATE = "state"
-PG_STATE_OFF = "OFF"
-
-SERVICES_WITHOUT_PG = ["FUTURA2", "AMBIENTA", "VOLTA", "LOGBOOK"]
-
-class Actions(StrEnum):
-    """Actions to control sections."""
-
-    ARM = "ARM"
-    DISARM = "DISARM"
-    PARTIAL_ARM = "PARTIAL_ARM"
+PG_STATE_AS_BINARY_STATE = {
+    "ON": True,
+    "OFF": False
+}

--- a/custom_components/jablotron_cloud/jablotron.py
+++ b/custom_components/jablotron_cloud/jablotron.py
@@ -1,0 +1,27 @@
+"""Client for Jablotron Cloud API."""
+
+from jablotronpy import Jablotron
+
+from .types import JablotronServiceData
+
+
+class JablotronClient:
+    """Client for Jablotron Cloud API."""
+
+    services: dict[int, JablotronServiceData] = {}
+
+    def __init__(self, username: str, password: str, default_pin: str | None = None, force_arm: bool = True) -> None:
+        """Initialize Jablotron client."""
+
+        self._username = username
+        self._password = password
+        self._default_pin = default_pin
+        self.force_arm = force_arm
+
+    def get_bridge(self) -> Jablotron:
+        """Return Jablotron bridge instance."""
+
+        bridge = Jablotron(self._username, self._password, self._default_pin)
+        bridge.perform_login()
+
+        return bridge

--- a/custom_components/jablotron_cloud/manifest.json
+++ b/custom_components/jablotron_cloud/manifest.json
@@ -1,15 +1,19 @@
 {
-  "domain": "jablotron_cloud",
-  "name": "Jablotron Cloud",
-  "codeowners": ["@pigotka"],
-  "config_flow": true,    
-  "dependencies": [],
-  "documentation": "https://github.com/Pigotka/ha-cc-jablotron-cloud",  
-  "homekit": {},
-  "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/Pigotka/ha-cc-jablotron-cloud/issues",
-  "requirements": ["jablotronpy==0.6.4"],
-  "ssdp": [],  
-  "version": "0.6.8",
-  "zeroconf": []
+    "domain": "jablotron_cloud",
+    "name": "Jablotron Cloud",
+    "codeowners": [
+        "@pigotka"
+    ],
+    "config_flow": true,
+    "documentation": "https://github.com/Pigotka/ha-cc-jablotron-cloud",
+    "integration_type": "hub",
+    "iot_class": "cloud_polling",
+    "issue_tracker": "https://github.com/Pigotka/ha-cc-jablotron-cloud/issues",
+    "loggers": [
+        "custom_components.jablotron_cloud"
+    ],
+    "requirements": [
+        "jablotronpy==0.7.0"
+    ],
+    "version": "0.7.0"
 }

--- a/custom_components/jablotron_cloud/strings.json
+++ b/custom_components/jablotron_cloud/strings.json
@@ -1,21 +1,49 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "pin": "[%key:common::config_flow::data::pin%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+    "config": {
+        "step": {
+            "user": {
+                "data": {
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "pin": "[%key:common::config_flow::data::pin%]",
+                    "force_update": "[%key:common::config_flow::data::force_update%]",
+                    "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+                    "timeout": "[%key:common::config_flow::data::timeout%]"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "pin": "[%key:common::config_flow::data::pin%]",
+                    "force_update": "[%key:common::config_flow::data::force_update%]",
+                    "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+                    "timeout": "[%key:common::config_flow::data::timeout%]"
+                }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "pin": "[%key:common::config_flow::data::pin%]",
+                    "force_update": "[%key:common::config_flow::data::force_update%]",
+                    "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+                    "timeout": "[%key:common::config_flow::data::timeout%]"
+                }
+            }
+        },
+        "error": {
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+            "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
         }
-      }
     },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    "exceptions": {
+        "invalid_pin": {
+            "message": "Provided pin code is not valid!"
+        }
     }
-  }
 }

--- a/custom_components/jablotron_cloud/strings.json
+++ b/custom_components/jablotron_cloud/strings.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "interval_too_short": "Minimum data refresh interval is 20 seconds!",
+            "interval_too_short": "Minimum data refresh interval is 30 seconds!",
             "timeout_too_low": "Minimum data refresh timeout is 10 seconds!",
             "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
         },

--- a/custom_components/jablotron_cloud/strings.json
+++ b/custom_components/jablotron_cloud/strings.json
@@ -33,6 +33,8 @@
             }
         },
         "error": {
+            "interval_too_short": "Minimum data refresh interval is 20 seconds!",
+            "timeout_too_low": "Minimum data refresh timeout is 10 seconds!",
             "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
         },
         "abort": {

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -1,132 +1,215 @@
-"""Support for controllable Jablotron PG sensors."""
+"""Support for Jablotron PG switches."""
+
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from jablotronpy import JablotronProgrammableGatesGate, UnauthorizedException, IncorrectPinCodeException
 
-from . import JablotronDataCoordinator
-from .const import COMP_ID, DOMAIN, PG_STATE, PG_STATE_OFF, SERVICE_TYPE
+from . import JablotronConfigEntry, JablotronData, JablotronDataCoordinator, JablotronClient
+from .const import DOMAIN
+from .utils import get_component_state, pg_state_to_binary_state
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,  # noqa: F841
+    entry: JablotronConfigEntry,
+    async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up Jablotron Cloud from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    services = coordinator.data
-    entities = []
+    """Register switch entity for each Jablotron service controllable programmable gate."""
 
-    if not services:
-        return
+    _LOGGER.debug("Adding Jablotron switch entities")
+    runtime_data: JablotronData = entry.runtime_data
+    coordinator = runtime_data.coordinator
+    client = runtime_data.client
 
-    for service_id, service_data in services.items():
+    # Get programmable gates for each service
+    entities: list[JablotronProgrammableGate] = []
+    for service_id, service_data in client.services.items():
+        # Get service details
+        service_name = service_data["name"]
+        service_type = service_data["type"]
+        service_firmware = service_data["firmware"]
 
-        gates_data = service_data["gates"]
-        if not gates_data:
-            continue
+        # Add all controllable programmable gate entities
+        _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
+        gates = service_data["gates"]
+        for gate in gates.get("programmableGates", []):
+            # Get gate details
+            gate: JablotronProgrammableGatesGate
+            gate_name = gate["name"]
+            gate_id = gate["cloud-component-id"]
+            gate_state = get_component_state(gate_id, gates["states"])
+            is_on = pg_state_to_binary_state(gate_state)
 
-        gates = gates_data.get("programmableGates", [])
-        for gate in gates:
-            can_control = gate["can-control"]
-            if not can_control:
+            # Check whether programmable gate is controllable
+            if not gate["can-control"]:
+                _LOGGER.debug("Programmable gate '%s' is uncontrollable, ignoring!", gate_name)
+
                 continue
 
-            gate_id = gate[COMP_ID]
-            gate_friendly_name = gate["name"]
-
-            _LOGGER.debug(
-                "Jablotron discovered controllable programmable gate: %s:%s",
-                gate_id,
-                gate_friendly_name,
-            )
+            # Add controllable programmable gate entity
+            _LOGGER.debug("Adding controllable programmable gate '%s'", gate_name)
             entities.append(
-                ProgrammableGate(coordinator, service_id, gate_id, gate_friendly_name)
+                JablotronProgrammableGate(
+                    coordinator,
+                    client,
+                    service_id,
+                    service_name,
+                    service_type,
+                    service_firmware,
+                    gate_id,
+                    gate_name,
+                    is_on
+                )
             )
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:  # noqa: F841
+    """Unload switch entities."""
+
     return True
 
 
-class ProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], SwitchEntity):
-    """Representation of programmable gate in jablotron system."""
+class JablotronProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], SwitchEntity):
+    """Representation of Jablotron Cloud switch entity."""
 
+    # Allow custom entity names
     _attr_has_entity_name = True
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     def __init__(
-        self: ProgrammableGate,
+        self: JablotronProgrammableGate,
         coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
+        service_name: str,
+        service_type: str,
+        service_firmware: str,
         gate_id: str,
-        friendly_name: str,
+        gate_name: str,
+        is_on: bool
     ) -> None:
-        """Pass coordinator to CoordinatorEntity."""
-        super().__init__(coordinator)
+        """Initialize Jablotron switch."""
+
+        # Define entity attributes
+        self._client = client
         self._service_id = service_id
+        self._service_name = service_name
+        self._service_type = service_type
+        self._service_firmware = service_firmware
         self._gate_id = gate_id
-        self._attr_unique_id = f"{service_id} {gate_id}"
-        self._attr_name = friendly_name
-        self._pin = coordinator.bridge.pin_code
+        self._gate_name = gate_name
+
+        # Define switch attributes
+        self._attr_name = gate_name
+        self._attr_unique_id = f"{service_id}_{gate_id}"
+        self._attr_is_on = is_on
+
+        # Initialize switch
+        super().__init__(coordinator)
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return the device info."""
+        """Return information about device."""
+
         return DeviceInfo(
-            identifiers={
-                # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, str(self._service_id))
-            },
-            name=self.coordinator.data[self._service_id]["service"]["name"],
+            identifiers={(DOMAIN, str(self._service_id))},
+            name=self._service_name,
             manufacturer="Jablotron",
-            model=self.coordinator.data[self._service_id]["service"][SERVICE_TYPE],
+            model=self._service_type,
+            sw_version=self._service_firmware
         )
 
-    def turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
-        bridge = self.coordinator.bridge
-        bridge.pin_code = self._pin
-        _LOGGER.debug("Turning on gate: %s using pin", self._gate_id)
-        bridge.control_programmable_gate(self._service_id, self._gate_id, True)
-        self._attr_is_on = True  # assume state
-        self.schedule_update_ha_state()
+    def turn_on(self, **kwargs) -> None:
+        """Send turn on request."""
 
-    def turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
-        bridge = self.coordinator.bridge
-        bridge.pin_code = self._pin
-        _LOGGER.debug("Turning off gate: %s using pin", self._gate_id)
-        bridge.control_programmable_gate(self._service_id, self._gate_id, False)
-        self._attr_is_on = False  # assume state
-        self.schedule_update_ha_state()
+        try:
+            # Send turn on request to gate
+            bridge = self._client.get_bridge()
+            turn_on_successful = bridge.control_programmable_gate(
+                service_id=self._service_id,
+                service_type=self._service_type,
+                component_id=self._gate_id,
+                state="ON"
+            )
 
+            # Set state to on if turn on action was successful
+            if turn_on_successful:
+                self._attr_is_on = True
+                self.schedule_update_ha_state()
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except IncorrectPinCodeException:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_pin"
+            )
+
+    def turn_off(self, **kwargs) -> None:
+        """Send turn off request."""
+
+        try:
+            # Send turn off request to gate
+            bridge = self._client.get_bridge()
+            turn_off_successful = bridge.control_programmable_gate(
+                service_id=self._service_id,
+                service_type=self._service_type,
+                component_id=self._gate_id,
+                state="OFF"
+            )
+
+            # Set state to off if turn off action was successful
+            if turn_off_successful:
+                self._attr_is_on = False
+                self.schedule_update_ha_state()
+        except UnauthorizedException as ex:
+            raise ConfigEntryAuthFailed(ex) from ex
+        except IncorrectPinCodeException:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_pin"
+            )
+
+    # noinspection DuplicatedCode
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+        """Process data retrieved by coordinator."""
 
-        if not self.coordinator.data or self._service_id not in self.coordinator.data:
-            _LOGGER.error("Invalid gate data. Maybe session expired")
+        # Get corresponding service data
+        _LOGGER.debug("Updating gate state for gate '%s'", self._gate_name)
+        service = self._client.services.get(self._service_id, None)
+        if not service:
+            _LOGGER.error("No data available for service '%d'!", self._service_id)
+
             return
 
-        gates_data = self.coordinator.data[self._service_id].get("gates", {})
-        states = gates_data.get("states", [])
-        for state in states:
-            if state[COMP_ID] == self._gate_id:
-                _LOGGER.debug("Updating programmable gate with data: %s", str(state))
-                self._attr_is_on = not state[PG_STATE] == PG_STATE_OFF
-                self.async_write_ha_state()
-                return
+        # Get service states
+        service_states = service["gates"]["states"]
+        if not service_states:
+            _LOGGER.warning("No states data available for service '%d'!", self._service_id)
+
+            return
+
+        # Get gate state
+        gate_state = get_component_state(self._gate_id, service_states)
+        if not gate_state:
+            _LOGGER.warning("No state available for gate '%s'!", self._gate_name)
+
+            return
+
+        # Set current programmable gate state
+        self._attr_is_on = pg_state_to_binary_state(gate_state)
+        self.async_write_ha_state()
+
+        _LOGGER.debug("Successfully updated gate state for gate '%s'", self._gate_name)

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "interval_too_short": "Minimální interval aktualizace dat je 20 sekund!",
+            "interval_too_short": "Minimální interval aktualizace dat je 30 sekund!",
             "timeout_too_low": "Minimální časový limit pro obnovení dat je 10 sekund!",
             "invalid_auth": "Nesprávné přihlašovací údaje pro Jablotron Cloud!"
         },

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -33,6 +33,8 @@
             }
         },
         "error": {
+            "interval_too_short": "Minimální interval aktualizace dat je 20 sekund!",
+            "timeout_too_low": "Minimální časový limit pro obnovení dat je 10 sekund!",
             "invalid_auth": "Nesprávné přihlašovací údaje pro Jablotron Cloud!"
         },
         "abort": {

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -1,21 +1,49 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Zařízení je již nakonfigurováno"
-        },
-        "error": {
-            "cannot_connect": "Není možné se připojit",
-            "invalid_auth": "Nesprávné přihlašovací údaje",
-            "unknown": "Neočekávaná chyba"
-        },
         "step": {
             "user": {
                 "data": {
-                    "pin": "PIN",
+                    "username": "Uživatelské jméno",
                     "password": "Heslo",
-                    "username": "Uživatelské jméno"
+                    "pin": "PIN (pro PGs)",
+                    "force_update": "Bypassovat chyby sekcí",
+                    "scan_interval": "Interval aktualizací (v sekundách)",
+                    "timeout": "Časový limit aktualizace (v sekundách)"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "username": "Uživatelské jméno",
+                    "password": "Heslo",
+                    "pin": "PIN (pro PGs)",
+                    "force_update": "Bypassovat chyby sekcí",
+                    "scan_interval": "Interval aktualizací (v sekundách)",
+                    "timeout": "Časový limit aktualizace (v sekundách)"
+                }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "username": "Uživatelské jméno",
+                    "password": "Heslo",
+                    "pin": "PIN (pro PGs)",
+                    "force_update": "Bypassovat chyby sekcí",
+                    "scan_interval": "Interval aktualizací (v sekundách)",
+                    "timeout": "Časový limit aktualizace (v sekundách)"
                 }
             }
+        },
+        "error": {
+            "invalid_auth": "Nesprávné přihlašovací údaje pro Jablotron Cloud!"
+        },
+        "abort": {
+            "already_configured": "Zařízení již bylo nakonfigurováno!",
+            "reconfigure_successful": "Zařízení bylo úspěšně překonfigurováno.",
+            "reauth_successful": "Přihlášení do služby Jablotron Cloud bylo úspěšně obnoveno."
+        }
+    },
+    "exceptions": {
+        "invalid_pin": {
+            "message": "Zadaný PIN kód není platný!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/en.json
+++ b/custom_components/jablotron_cloud/translations/en.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "interval_too_short": "Minimum data refresh interval is 20 seconds!",
+            "interval_too_short": "Minimum data refresh interval is 30 seconds!",
             "timeout_too_low": "Minimum data refresh timeout is 10 seconds!",
             "invalid_auth": "Incorrect login details for Jablotron Cloud!"
         },

--- a/custom_components/jablotron_cloud/translations/en.json
+++ b/custom_components/jablotron_cloud/translations/en.json
@@ -1,21 +1,49 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
         "step": {
             "user": {
                 "data": {
-                    "pin": "PIN",
+                    "username": "Username",
                     "password": "Password",
-                    "username": "Username"
+                    "pin": "PIN (for PGs)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update interval (seconds)",
+                    "timeout": "Update timeout (seconds)"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "username": "Username",
+                    "password": "Password",
+                    "pin": "PIN (for PGs)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update interval (seconds)",
+                    "timeout": "Update timeout (seconds)"
+                }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "username": "Username",
+                    "password": "Password",
+                    "pin": "PIN (for PGs)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update interval (seconds)",
+                    "timeout": "Update timeout (seconds)"
                 }
             }
+        },
+        "error": {
+            "invalid_auth": "Incorrect login details for Jablotron Cloud!"
+        },
+        "abort": {
+            "already_configured": "The device has already been configured!",
+            "reconfigure_successful": "The device has been successfully reconfigured.",
+            "reauth_successful": "Login to Jablotron Cloud has been successfully restored."
+        }
+    },
+    "exceptions": {
+        "invalid_pin": {
+            "message": "The entered pin code is not valid!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/en.json
+++ b/custom_components/jablotron_cloud/translations/en.json
@@ -33,6 +33,8 @@
             }
         },
         "error": {
+            "interval_too_short": "Minimum data refresh interval is 20 seconds!",
+            "timeout_too_low": "Minimum data refresh timeout is 10 seconds!",
             "invalid_auth": "Incorrect login details for Jablotron Cloud!"
         },
         "abort": {

--- a/custom_components/jablotron_cloud/translations/nl.json
+++ b/custom_components/jablotron_cloud/translations/nl.json
@@ -33,6 +33,8 @@
             }
         },
         "error": {
+            "interval_too_short": "De minimale interval voor het vernieuwen van gegevens is 20 seconden!",
+            "timeout_too_low": "De minimale time-out voor het vernieuwen van gegevens is 10 seconden!",
             "invalid_auth": "Onjuiste inloggegevens voor Jablotron Cloud!"
         },
         "abort": {

--- a/custom_components/jablotron_cloud/translations/nl.json
+++ b/custom_components/jablotron_cloud/translations/nl.json
@@ -1,21 +1,49 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Apparaat is al geconfigureerd"
-        },
-        "error": {
-            "cannot_connect": "Kan geen verbinding maken",
-            "invalid_auth": "Ongeldige authenticatie",
-            "unknown": "Onverwachte fout"
-        },
         "step": {
             "user": {
                 "data": {
-                    "pin": "PIN",
+                    "username": "Gebruikersnaam",
                     "password": "Wachtwoord",
-                    "username": "Gebruikersnaam"
+                    "pin": "PIN (voor PG's)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update-interval (seconden)",
+                    "timeout": "Update-time-out (seconden)"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "username": "Gebruikersnaam",
+                    "password": "Wachtwoord",
+                    "pin": "PIN (voor PG's)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update-interval (seconden)",
+                    "timeout": "Update-time-out (seconden)"
+                }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "username": "Gebruikersnaam",
+                    "password": "Wachtwoord",
+                    "pin": "PIN (voor PG's)",
+                    "force_update": "Bypass section errors",
+                    "scan_interval": "Update-interval (seconden)",
+                    "timeout": "Update-time-out (seconden)"
                 }
             }
+        },
+        "error": {
+            "invalid_auth": "Onjuiste inloggegevens voor Jablotron Cloud!"
+        },
+        "abort": {
+            "already_configured": "Het apparaat is al geconfigureerd!",
+            "reconfigure_successful": "Het apparaat is succesvol opnieuw geconfigureerd.",
+            "reauth_successful": "De aanmelding bij Jablotron Cloud is succesvol hersteld."
+        }
+    },
+    "exceptions": {
+        "invalid_pin": {
+            "message": "De ingevoerde pincode is niet geldig!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/nl.json
+++ b/custom_components/jablotron_cloud/translations/nl.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "interval_too_short": "De minimale interval voor het vernieuwen van gegevens is 20 seconden!",
+            "interval_too_short": "De minimale interval voor het vernieuwen van gegevens is 30 seconden!",
             "timeout_too_low": "De minimale time-out voor het vernieuwen van gegevens is 10 seconden!",
             "invalid_auth": "Onjuiste inloggegevens voor Jablotron Cloud!"
         },

--- a/custom_components/jablotron_cloud/translations/sk.json
+++ b/custom_components/jablotron_cloud/translations/sk.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "interval_too_short": "Minimálny interval aktualizácie dát je 20 sekúnd!",
+            "interval_too_short": "Minimálny interval aktualizácie dát je 30 sekúnd!",
             "timeout_too_low": "Minimálny časový limit na obnovenie dát je 10 sekúnd!",
             "invalid_auth": "Nesprávne prihlasovacie údaje pre Jablotron Cloud!"
         },

--- a/custom_components/jablotron_cloud/translations/sk.json
+++ b/custom_components/jablotron_cloud/translations/sk.json
@@ -1,21 +1,49 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Zariadenie je už nakonfigurované"
-        },
-        "error": {
-            "cannot_connect": "Nie je možné sa pripojiť",
-            "invalid_auth": "Nesprávne prihlasovacie údaje",
-            "unknown": "Neočakávaná chyba"
-        },
         "step": {
             "user": {
                 "data": {
-                    "pin": "PIN",
+                    "username": "Užívateľské meno",
                     "password": "Heslo",
-                    "username": "Prihlasovacie meno"
+                    "pin": "PIN (pre PGs)",
+                    "force_update": "Bypassovať chyby sekcií",
+                    "scan_interval": "Interval aktualizácií (v sekundách)",
+                    "timeout": "Časový limit aktualizácie (v sekundách)"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "username": "Užívateľské meno",
+                    "password": "Heslo",
+                    "pin": "PIN (pre PGs)",
+                    "force_update": "Bypassovať chyby sekcií",
+                    "scan_interval": "Interval aktualizácií (v sekundách)",
+                    "timeout": "Časový limit aktualizácie (v sekundách)"
+                }
+            },
+            "reauth_confirm": {
+                "data": {
+                    "username": "Užívateľské meno",
+                    "password": "Heslo",
+                    "pin": "PIN (pre PGs)",
+                    "force_update": "Bypassovať chyby sekcií",
+                    "scan_interval": "Interval aktualizácií (v sekundách)",
+                    "timeout": "Časový limit aktualizácie (v sekundách)"
                 }
             }
+        },
+        "error": {
+            "invalid_auth": "Nesprávne prihlasovacie údaje pre Jablotron Cloud!"
+        },
+        "abort": {
+            "already_configured": "Zariadenie už bolo nakonfigurované!",
+            "reconfigure_successful": "Zariadenie bolo úspešne prekonfigurované.",
+            "reauth_successful": "Prihlásenie do služby Jablotron Cloud bolo úspešne obnovené."
+        }
+    },
+    "exceptions": {
+        "invalid_pin": {
+            "message": "Zadaný PIN kód nie je platný!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/sk.json
+++ b/custom_components/jablotron_cloud/translations/sk.json
@@ -33,6 +33,8 @@
             }
         },
         "error": {
+            "interval_too_short": "Minimálny interval aktualizácie dát je 20 sekúnd!",
+            "timeout_too_low": "Minimálny časový limit na obnovenie dát je 10 sekúnd!",
             "invalid_auth": "Nesprávne prihlasovacie údaje pre Jablotron Cloud!"
         },
         "abort": {

--- a/custom_components/jablotron_cloud/types.py
+++ b/custom_components/jablotron_cloud/types.py
@@ -1,0 +1,15 @@
+from typing import TypedDict
+
+from jablotronpy import JablotronSections, JablotronProgrammableGates, JablotronThermoDevice
+
+JablotronServiceData = TypedDict(
+    "JablotronServiceData",
+    {
+        "name": str,
+        "type": str,
+        "firmware": str,
+        "alarm": JablotronSections,
+        "gates": JablotronProgrammableGates,
+        "thermo": list[JablotronThermoDevice]
+    }
+)

--- a/custom_components/jablotron_cloud/utils.py
+++ b/custom_components/jablotron_cloud/utils.py
@@ -1,0 +1,35 @@
+"""Utils for Jablotron Cloud integration."""
+
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import STATE_UNKNOWN
+from jablotronpy import JablotronSectionsState, JablotronProgrammableGatesState
+
+from .const import SECTION_STATE_AS_ALARM_STATE, PG_STATE_AS_BINARY_STATE
+
+
+def get_component_state(
+    component_id: str,
+    states: list[JablotronSectionsState | JablotronProgrammableGatesState]
+) -> str | None:
+    """Return Jablotron component state."""
+
+    # Get component state dict
+    component_state = next(filter(lambda state: state["cloud-component-id"] == component_id, states), None)
+    if not component_state:
+        return None
+
+    # Return component state value
+    component_state: JablotronSectionsState | JablotronProgrammableGatesState
+    return component_state["state"]
+
+
+def section_state_to_alarm_state(state: str | None) -> AlarmControlPanelState:
+    """Convert section state to AlarmControlPanelState."""
+
+    return SECTION_STATE_AS_ALARM_STATE.get(state, STATE_UNKNOWN)
+
+
+def pg_state_to_binary_state(state: str | None) -> bool:
+    """Convert programmable gate state to boolean value."""
+
+    return PG_STATE_AS_BINARY_STATE.get(state, False)

--- a/custom_components/jablotron_cloud/utils.py
+++ b/custom_components/jablotron_cloud/utils.py
@@ -1,10 +1,31 @@
 """Utils for Jablotron Cloud integration."""
 
+import logging
+
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import callback
+from homeassistant.helpers.entity_registry import RegistryEntry
 from jablotronpy import JablotronSectionsState, JablotronProgrammableGatesState
 
 from .const import SECTION_STATE_AS_ALARM_STATE, PG_STATE_AS_BINARY_STATE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def update_unique_id(entity_entry: RegistryEntry) -> dict | None:
+    """Migrate unique id of existing entities to the new schema."""
+
+    # Check whether unique id contains space
+    if " " in entity_entry.unique_id:
+        _LOGGER.info("Migrating entity '%s' to the new unique id schema", entity_entry.entity_id)
+
+        return {
+            "new_unique_id": entity_entry.unique_id.replace(" ", "_")
+        }
+
+    return None
 
 
 def get_component_state(

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Jablotron Cloud",
-  "render_readme": true,  
-  "homeassistant": "2024.11.0" 
+    "name": "Jablotron Cloud",
+    "render_readme": true,
+    "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
Hi @Pigotka,

It's time to submit a PR for this integration as well. As you can see, it is quite a lot of work. I will try to describe and explain everything.

## Improvements
* Added option to specify whether to bypass section errors by default
* Added option to specify how often to poll data from Jablotron Cloud
* Added option to specify time limit for polling data from Jablotron Cloud
* Integration (re)configuration dialog now remembers user input
* Added option to change integration settings - reconfigure
* Added automatic notification to change login credentials if they are no longer valid
* Entities now have the correct state right at creation
* Incorrect pin now returns a user friendly error
* Added information about the alarm control panel firmware
* Improved translations - NL is not complete

## Fixes
* Programmable gate control actions now correctly uses the default pin - fixes #47

## Changes
* Each control action and data polling uses a new API login - this should eliminate expired sessions
* Timeout when polling data throws a warning in the log instead of raising an error - entities are no longer marked as unavailable
* When performing control actions, the state of the entity is modified only in case of successful control
* Removed space from entity unique id attribute **- see notes**

## Testing
I tested the integration thoroughly and tried to simulate all scenarios that may occur.
Unfortunately I have neither temperature sensors nor programmable gates in my system. So I tested these entities by mocking the API data and everything seemed to work.
I didn't even notice any of the sections being marked as unavailable during testing.
I currently have a test instance of HA set up and am letting the integration run.

Please, also test the integration and verify that I didn't make a mistake somewhere during the rewrite before merging.

## Notes
**The unique entity ID contained a space, which didn't seem to be according to the rules. I fixed that, and added a method that migrates existing unique IDs with a space to new unique IDs with an underscore. This means that all entities should be preserved, just have their unique IDs fixed in the background. Users should not notice anything.**

---

It is now checked if the control action of the alarm and PGs was successful. If so, the corresponding entity state is set.
For alarms we could theoretically set the state to DISARMED/ARMED_HOME/ARMED_AWAY immediately, but for now I left it at ARMING/DISARMING.

---

In case an alarm is raised in a section, this information is not reflected by changing the state of the section in API response, but is written to the list of current events. Unfortunately, the information about which section the alarm is related to is not quite appropriately represented, so I did not include this functionality - i.e. reactions to alarms - in this PR.
We can talk about this separately.

---

The integration does not automatically add or remove entities. To find new devices and remove old ones, you must reinitialize the integration.
This behavior is the same as in the current version.