### PR TITLE
#60 Enhance Jablotron sensor support for sections

### DIFF
--- a/custom_components/jablotron_cloud/sensor.py
+++ b/custom_components/jablotron_cloud/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Jablotron thermo device sensors."""
+"""Support for Jablotron thermo device sensors and state-only section sensors."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import logging
 from jablotronpy import JablotronThermoDevice
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .const import DOMAIN
+from .utils import get_component_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,28 +25,29 @@ async def async_setup_entry(
     entry: JablotronConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Register sensor entity for each Jablotron service thermo device."""
+    """Register sensor entities for each Jablotron service thermo device and non-controllable sections."""
 
     _LOGGER.debug("Adding Jablotron sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get thermo devices for each service
-    entities: list[JablotronSensor] = []
+    # Collect entities (thermo devices + non-controllable section state sensors)
+    entities: list[SensorEntity] = []
+
     for service_id, service_data in client.services.items():
         # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
-        # Add all thermo device entities
+        # Add thermo device entities
         _LOGGER.debug("Getting available thermo devices for service '%s'", service_name)
-        thermo_devices = service_data["thermo"]
+        thermo_devices = service_data.get("thermo", [])
         for thermo_device in thermo_devices:
             # Get thermo device details
             thermo_device_id = thermo_device["object-device-id"]
-            current_temperature = thermo_device["temperature"]
+            current_temperature = thermo_device.get("temperature")
 
             # Add thermo device entity
             _LOGGER.debug("Adding thermo device '%s'", thermo_device_id)
@@ -62,6 +64,36 @@ async def async_setup_entry(
                 )
             )
 
+        # Add non-controllable section state sensors
+        _LOGGER.debug("Getting available sections for service '%s'", service_name)
+        alarm = service_data.get("alarm", {})
+        for section in alarm.get("sections", []):
+            section_name = section.get("name")
+            section_id = section.get("cloud-component-id")
+
+            # Only register sensors for sections that are NOT controllable
+            if section.get("can-control", True):
+                _LOGGER.debug("Section '%s' is controllable, ignoring for state-only sensor", section_name)
+                continue
+
+            # Get initial state (may be None)
+            section_state = get_component_state(section_id, alarm.get("states", []))
+
+            _LOGGER.debug("Adding non-controllable section state sensor '%s'", section_name)
+            entities.append(
+                JablotronSectionStateSensor(
+                    coordinator,
+                    client,
+                    service_id,
+                    service_name,
+                    service_type,
+                    service_firmware,
+                    section_id,
+                    section_name,
+                    section_state,
+                )
+            )
+
     async_add_entities(entities)
 
 
@@ -72,7 +104,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -
 
 
 class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity):
-    """Representation of Jablotron Cloud sensor entity."""
+    """Representation of Jablotron Cloud thermometer sensor entity."""
 
     # Allow custom entity names
     _attr_has_entity_name = True
@@ -106,13 +138,12 @@ class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity)
         self._attr_unique_id = f"{service_id}_{thermo_device_id}"
         self._attr_native_value = current_temperature
 
-        # Initialize sensor
+        # Initialize coordinator entity
         super().__init__(coordinator)
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return information about device."""
-
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._service_id))},
             name=self._service_name,
@@ -124,40 +155,95 @@ class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity)
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
-        # Get corresponding service data
-        _LOGGER.debug("Updating thermo device state for device '%s'", self._thermo_device_id)
-        service = self._client.services.get(self._service_id, None)
+        _LOGGER.debug("Updating thermo sensor for '%s'", self._thermo_device_id)
+        service = self._client.services.get(self._service_id)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
-
             return
 
-        # Get service devices
-        thermo_devices = service["thermo"]
-        if not thermo_devices:
-            _LOGGER.warning("No thermo devices available for service '%d'!", self._service_id)
+        thermo_devices = service.get("thermo", [])
+        for thermo in thermo_devices:
+            if thermo.get("object-device-id") == self._thermo_device_id:
+                self._attr_native_value = thermo.get("temperature")
+                self.async_write_ha_state()
+                _LOGGER.debug("Successfully updated thermo sensor '%s' to '%s'", self._thermo_device_id, self._attr_native_value)
+                return
 
-            return
+        _LOGGER.warning("No thermo device '%s' found for service '%d'", self._thermo_device_id, self._service_id)
 
-        # Get device
-        thermo_device: JablotronThermoDevice | None = next(
-            filter(
-                lambda device: device["object-device-id"] == self._thermo_device_id,
-                thermo_devices,
-            ),
-            None,
+
+class JablotronSectionStateSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity):
+    """Representation of a Jablotron section state sensor for non-controllable sections."""
+
+    # Allow custom entity names
+    _attr_has_entity_name = True
+
+    def __init__(
+        self: JablotronSectionStateSensor,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
+        service_id: int,
+        service_name: str,
+        service_type: str,
+        service_firmware: str,
+        section_id: str,
+        section_name: str,
+        initial_state: str | None,
+    ) -> None:
+        """Initialize Jablotron section state sensor."""
+
+        # Define entity attributes
+        self._client = client
+        self._service_id = service_id
+        self._service_name = service_name
+        self._service_type = service_type
+        self._service_firmware = service_firmware
+        self._section_id = section_id
+        self._section_name = section_name
+
+        # Define sensor attributes
+        # Name identifies this is the section state
+        self._attr_name = f"{section_name}_state"
+        # Avoid unique_id collision with alarm control panel entities
+        self._attr_unique_id = f"{service_id}_{section_id}_state"
+        # Initial value (may be None)
+        self._attr_native_value = initial_state if initial_state is not None else STATE_UNKNOWN
+
+        # Initialize coordinator entity
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information about device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._service_id))},
+            name=self._service_name,
+            manufacturer="Jablotron",
+            model=self._service_type,
+            sw_version=self._service_firmware,
         )
-        if not thermo_device:
-            _LOGGER.warning("No thermo device found with id '%s'!", self._thermo_device_id)
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Process data retrieved by coordinator and update sensor state."""
+        _LOGGER.debug("Updating section state for '%s'", self._section_name)
+        service = self._client.services.get(self._service_id)
+        if not service:
+            _LOGGER.error("No data available for service '%d'!", self._service_id)
             return
 
-        # Set current thermo device state
-        self._attr_native_value = thermo_device["temperature"]
+        service_states = service.get("alarm", {}).get("states")
+        if not service_states:
+            _LOGGER.warning("No states data available for service '%d'!", self._service_id)
+            return
+
+        section_state = get_component_state(self._section_id, service_states)
+        if section_state is None:
+            _LOGGER.warning("No state available for section '%s'!", self._section_name)
+            return
+
+        # Expose the raw section state string (e.g. "ARM", "DISARM", "PARTIAL_ARM")
+        self._attr_native_value = section_state
         self.async_write_ha_state()
 
-        _LOGGER.debug(
-            "Successfully updated thermo device state for device '%s'",
-            self._thermo_device_id,
-        )
+        _LOGGER.debug("Successfully updated section state for '%s' to '%s'", self._section_name, section_state)


### PR DESCRIPTION
#60 Summary

Adds sensors for Jablotron sections that are not controllable (can-control == false). These sensors expose only the raw section state returned by the Jablotron Cloud API (e.g. "ARM", "DISARM", "PARTIAL_ARM"). This enables read-only accounts to surface section state in Home Assistant when control actions are not permitted. Why

Previously sections with can-control == false were skipped entirely, leaving no Home Assistant entity to show the section state for read-only users. This change provides visibility for those sections without adding control capabilities. What changed

Modified custom_components/jablotron_cloud/sensor.py: Registers JablotronSectionStateSensor entities for non-controllable sections. Each sensor's value is the raw section state string from the API. Unique IDs use the pattern: {service_id}_{section_id}_state to avoid collisions with existing alarm_control_panel entities. Thermo device sensors remain unchanged aside from being collected together in the same platform file. Implementation notes

The sensor implementation follows the same CoordinatorEntity pattern used elsewhere in the integration and mirrors the approach used by binary_sensor.py for uncontrollable programmable gates. The sensor exposes the raw state string intentionally (rather than mapping to Home Assistant alarm states), so consumers can see the exact API status for read-only sections.