### PR TITLE
Refactor entity platforms with shared base class and async control methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# Jablotron Cloud - Home Assistant Custom Integration
+
+## Project Overview
+Custom HACS integration connecting Jablotron alarm systems to Home Assistant via `jablotronpy` cloud API.
+Cloud-polling hub with 5 entity platforms: alarm_control_panel, binary_sensor, climate, sensor, switch.
+
+## Architecture
+- `JablotronClient` (jablotron.py) - credential holder, `get_bridge()` creates fresh login each call
+- `JablotronDataCoordinator` (__init__.py) - polls API, mutates `client.services` dict in-place; `coordinator.data` is unused (stays None)
+- Entities read state from `client.services[service_id]` in `_handle_coordinator_update()`, not from `coordinator.data`
+- `can-control` flag splits same data source into read-only vs read-write platforms (binary_sensor/switch, sensor/climate)
+- All entities from same Jablotron service share one HA device via `identifiers={(DOMAIN, str(service_id))}`
+- No shared entity base class - patterns are copy-pasted across platforms
+
+## Code Style
+- Ruff linting matching HA core rules (see pyproject.toml): line length 120, Python 3.12, Google docstrings
+- `async_add_executor_job` for blocking jablotronpy calls
+- Optimistic state updates after control actions
+- Config flow version 3.1; migration from v2 in `async_migrate_entry`
+
+## HA Development Guidelines
+These rules come from the Home Assistant developer docs and apply to all code in this integration.
+
+### General Style
+- PEP 8 + PEP 257 enforced; Ruff is the formatter
+- F-strings for formatting everywhere EXCEPT logging (use `%s` formatting in log calls)
+- Comments must be complete sentences ending with a period
+- Constants, list contents, and dict contents should be alphabetically ordered
+- Fully typed code; use type annotations, not docstring types
+
+### Entity Rules
+- `has_entity_name = True` is mandatory for new integrations
+- Entity names should use translations, not hardcoded English strings
+- Use `_attr_` for static/simple values; use `@property` only when logic is needed
+- Properties must NEVER do I/O — only return values from memory
+- Never pass `hass` as entity constructor param — access via `self.hass` after init
+- Never call `update()` inside entity constructors
+- Icon should be set via `icons.json` translation, not `icon` property (unless dynamic)
+- Avoid changing `device_class` or `supported_features` after initial creation
+- Use `entity_category` CONFIG for config entities, DIAGNOSTIC for read-only diagnostics
+
+### Data Coordinator Rules
+- Use `async_config_entry_first_refresh()` during setup for initial data load
+- Raise `ConfigEntryAuthFailed` for auth errors (halts updates, triggers reauth)
+- Raise `UpdateFailed("message")` for transient API errors (allows retry)
+- `asyncio.TimeoutError` and `aiohttp.ClientError` are auto-handled by coordinator
+- Minimum polling interval: 5 seconds
+
+### Config Entry Rules
+- Never mutate `ConfigEntry` data directly — use `async_update_entry()`
+- Forward platform setup via `async_forward_entry_setups(entry, PLATFORMS)`
+- Forward unloading via `async_unload_platforms(entry, PLATFORMS)`
+
+### Translations
+- All user-facing strings must go through `strings.json` translation system
+- Use `[%key:component::domain::section::key%]` references for shared HA strings
+- Exception messages use `HomeAssistantError(translation_domain=DOMAIN, translation_key="...")`
+- Entity names with `has_entity_name = True` support translation via `translation_key`
+
+### Logging
+- Use `_LOGGER = logging.getLogger(__name__)` — platform name is added automatically
+- No periods at end of log messages
+- Never log secrets (API keys, tokens, passwords, usernames)
+- Prefer `_LOGGER.debug` over `_LOGGER.info` for non-user-facing messages
+- Use `%s` formatting in log calls (not f-strings) to avoid evaluating suppressed messages
+
+### Dependencies
+- All API code must live in a third-party PyPI library (jablotronpy), not in this integration
+- Requirements must be pinned to exact versions in manifest.json
+
+## Commands
+- `ruff check custom_components/` - lint
+- `ruff format custom_components/` - format
+
+## Dependencies
+- Runtime: `jablotronpy==0.7.3` (pinned in manifest.json)
+- Dev: `homeassistant>=2024.11.0`, `ruff>=0.14.10` (in pyproject.toml)
+- No tests exist in this repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,6 @@ Cloud-polling hub with 5 entity platforms: alarm_control_panel, binary_sensor, c
 - Entities read state from `client.services[service_id]` in `_handle_coordinator_update()`, not from `coordinator.data`
 - `can-control` flag splits same data source into read-only vs read-write platforms (binary_sensor/switch, sensor/climate)
 - All entities from same Jablotron service share one HA device via `identifiers={(DOMAIN, str(service_id))}`
-- No shared entity base class - patterns are copy-pasted across platforms
 
 ## Code Style
 - Ruff linting matching HA core rules (see pyproject.toml): line length 120, Python 3.12, Google docstrings

--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -198,8 +198,11 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                 )
 
                 _LOGGER.debug(
-                    "Successfully discovered available platforms for service '%d'",
+                    "Service '%d' discovered: %d sections, %d gates, %d thermo devices",
                     service_id,
+                    len(self._client.services[service_id]["alarm"].get("sections", [])),
+                    len(self._client.services[service_id]["gates"].get("programmableGates", [])),
+                    len(self._client.services[service_id]["thermo"]),
                 )
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 import logging
 
 from jablotronpy import IncorrectPinCodeException, UnauthorizedException
@@ -14,12 +15,11 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
+from . import JablotronConfigEntry, JablotronData
 from .const import DOMAIN
+from .entity import JablotronEntity
 from .utils import get_component_state, section_state_to_alarm_state
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,24 +32,18 @@ async def async_setup_entry(
 ) -> None:
     """Register alarm panel entity for each Jablotron service section."""
 
-    _LOGGER.debug("Adding Jablotron alarm control panel entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get sections for each service
     entities: list[JablotronAlarmControlPanel] = []
     for service_id, service_data in client.services.items():
-        # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
-        # Add all controllable section entities
-        _LOGGER.debug("Getting available sections for service '%s'", service_name)
         alarm = service_data["alarm"]
         for section in alarm["sections"]:
-            # Get section details
             section_name = section["name"]
             section_id = section["cloud-component-id"]
             partial_arm_enabled = section["partial-arm-enabled"]
@@ -57,14 +51,10 @@ async def async_setup_entry(
             section_state = get_component_state(section_id, alarm["states"])
             current_state = section_state_to_alarm_state(section_state)
 
-            # Check whether section is controllable
             if not section["can-control"]:
                 _LOGGER.debug("Section '%s' is not controllable, ignoring!", section_name)
-
                 continue
 
-            # Add controllable section entity
-            _LOGGER.debug("Adding controllable section '%s'", section_name)
             entities.append(
                 JablotronAlarmControlPanel(
                     coordinator,
@@ -84,22 +74,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
-    """Unload alarm panel entities."""
-
-    return True
-
-
-class JablotronAlarmControlPanel(CoordinatorEntity[JablotronDataCoordinator], AlarmControlPanelEntity):
+class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
     """Representation of Jablotron Cloud alarm panel entity."""
 
-    # Allow custom entity names
-    _attr_has_entity_name = True
-
     def __init__(
-        self: JablotronAlarmControlPanel,
-        coordinator: JablotronDataCoordinator,
-        client: JablotronClient,
+        self,
+        coordinator,
+        client,
         service_id: int,
         service_name: str,
         service_type: str,
@@ -111,166 +92,124 @@ class JablotronAlarmControlPanel(CoordinatorEntity[JablotronDataCoordinator], Al
         current_state: AlarmControlPanelState,
     ) -> None:
         """Initialize Jablotron alarm panel."""
-
-        # Define entity attributes
-        self._client = client
-        self._service_id = service_id
-        self._service_name = service_name
-        self._service_type = service_type
-        self._service_firmware = service_firmware
         self._section_id = section_id
         self._section_name = section_name
-
-        # Define panel attributes
         self._attr_name = section_name
         self._attr_unique_id = f"{service_id}_{section_id}"
         self._supports_partial_arm = partial_arm_enabled
         self._authorization_required = requires_authorization
         self._attr_alarm_state = current_state
-
-        # Initialize alarm control panel
-        super().__init__(coordinator)
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
     @property
     def code_format(self) -> CodeFormat | None:
         """Disable code for sections that don't require it."""
-
         return CodeFormat.NUMBER if self._authorization_required else None
 
     @property
     def code_arm_required(self) -> bool:
         """Whether code is required for arm actions."""
-
         return self._authorization_required
 
     @property
     def supported_features(self) -> AlarmControlPanelEntityFeature:
         """Return list of supported features."""
-
         supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
         if self._supports_partial_arm:
             supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-
         return supported_features
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about device."""
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, str(self._service_id))},
-            name=self._service_name,
-            manufacturer="Jablotron",
-            model=self._service_type,
-            sw_version=self._service_firmware,
-        )
-
-    def alarm_disarm(self, code: str | None = None) -> None:
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm request."""
-
         try:
-            # Send disarm request to section
             code = self.code_or_default_code(code)
-            bridge = self._client.get_bridge()
-            disarm_successful = bridge.control_section(
-                service_id=self._service_id,
-                service_type=self._service_type,
-                component_id=self._section_id,
-                state="DISARM",
-                pin_code=code,
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            disarm_successful = await self.hass.async_add_executor_job(
+                partial(
+                    bridge.control_section,
+                    service_id=self._service_id,
+                    service_type=self._service_type,
+                    component_id=self._section_id,
+                    state="DISARM",
+                    pin_code=code,
+                )
             )
-
-            # Set state to disarming if disarm action was successful
             if disarm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.DISARMING
-                self.schedule_update_ha_state()
+                self.async_write_ha_state()
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin")
+        except IncorrectPinCodeException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
-    def alarm_arm_away(self, code: str | None = None) -> None:
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm request."""
-
         try:
-            # Send arm request to section
             code = self.code_or_default_code(code)
-            bridge = self._client.get_bridge()
-            arm_successful = bridge.control_section(
-                service_id=self._service_id,
-                service_type=self._service_type,
-                component_id=self._section_id,
-                state="ARM",
-                pin_code=code,
-                force=self._client.force_arm,
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            arm_successful = await self.hass.async_add_executor_job(
+                partial(
+                    bridge.control_section,
+                    service_id=self._service_id,
+                    service_type=self._service_type,
+                    component_id=self._section_id,
+                    state="ARM",
+                    pin_code=code,
+                    force=self._client.force_arm,
+                )
             )
-
-            # Set state to arming if arm action was successful
             if arm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
-                self.schedule_update_ha_state()
+                self.async_write_ha_state()
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin")
+        except IncorrectPinCodeException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
-    def alarm_arm_home(self, code: str | None = None) -> None:
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send partial arm request."""
-
-        # Check that partial arm is supported
         if not self._supports_partial_arm:
             return
 
         try:
-            # Send partial arm request to section
             code = self.code_or_default_code(code)
-            bridge = self._client.get_bridge()
-            arm_successful = bridge.control_section(
-                service_id=self._service_id,
-                service_type=self._service_type,
-                component_id=self._section_id,
-                state="PARTIAL_ARM",
-                pin_code=code,
-                force=self._client.force_arm,
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            arm_successful = await self.hass.async_add_executor_job(
+                partial(
+                    bridge.control_section,
+                    service_id=self._service_id,
+                    service_type=self._service_type,
+                    component_id=self._section_id,
+                    state="PARTIAL_ARM",
+                    pin_code=code,
+                    force=self._client.force_arm,
+                )
             )
-
-            # Set state to arming if partial arm action was successful
             if arm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
-                self.schedule_update_ha_state()
+                self.async_write_ha_state()
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin")
+        except IncorrectPinCodeException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
-        # Get corresponding service data
-        _LOGGER.debug("Updating alarm state for section '%s'", self._section_name)
         service = self._client.services.get(self._service_id, None)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
-
             return
 
-        # Get service states
         service_states = service["alarm"]["states"]
         if not service_states:
             _LOGGER.warning("No states data available for service '%d'!", self._service_id)
-
             return
 
-        # Get section state
         section_state = get_component_state(self._section_id, service_states)
         if not section_state:
             _LOGGER.warning("No state available for section '%s'!", self._section_name)
-
             return
 
-        # Set current section state
         self._attr_alarm_state = section_state_to_alarm_state(section_state)
         self.async_write_ha_state()
-
-        _LOGGER.debug("Successfully updated alarm state for section '%s'", self._section_name)

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import JablotronConfigEntry, JablotronData
+from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .const import DOMAIN
 from .entity import JablotronEntity
 from .utils import get_component_state, section_state_to_alarm_state
@@ -79,8 +79,8 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
 
     def __init__(
         self,
-        coordinator,
-        client,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
         service_name: str,
         service_type: str,

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
 ) -> None:
     """Register alarm panel entity for each Jablotron service section."""
 
+    _LOGGER.debug("Adding Jablotron alarm control panel entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
@@ -42,6 +43,7 @@ async def async_setup_entry(
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
+        _LOGGER.debug("Getting available sections for service '%s'", service_name)
         alarm = service_data["alarm"]
         for section in alarm["sections"]:
             section_name = section["name"]
@@ -55,6 +57,7 @@ async def async_setup_entry(
                 _LOGGER.debug("Section '%s' is not controllable, ignoring!", section_name)
                 continue
 
+            _LOGGER.debug("Adding controllable section '%s' with initial state '%s'", section_name, section_state)
             entities.append(
                 JablotronAlarmControlPanel(
                     coordinator,
@@ -123,6 +126,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         """Send disarm request."""
         try:
             code = self.code_or_default_code(code)
+            _LOGGER.debug("Sending disarm for section '%s' (service %d)", self._section_name, self._service_id)
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             disarm_successful = await self.hass.async_add_executor_job(
                 partial(
@@ -146,6 +150,12 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         """Send arm request."""
         try:
             code = self.code_or_default_code(code)
+            _LOGGER.debug(
+                "Sending arm away for section '%s' (service %d, force=%s)",
+                self._section_name,
+                self._service_id,
+                self._client.force_arm,
+            )
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             arm_successful = await self.hass.async_add_executor_job(
                 partial(
@@ -173,6 +183,12 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
 
         try:
             code = self.code_or_default_code(code)
+            _LOGGER.debug(
+                "Sending arm home for section '%s' (service %d, force=%s)",
+                self._section_name,
+                self._service_id,
+                self._client.force_arm,
+            )
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             arm_successful = await self.hass.async_add_executor_job(
                 partial(
@@ -211,5 +227,6 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
             _LOGGER.warning("No state available for section '%s'!", self._section_name)
             return
 
+        _LOGGER.debug("Section '%s' received state '%s'", self._section_name, section_state)
         self._attr_alarm_state = section_state_to_alarm_state(section_state)
         self.async_write_ha_state()

--- a/custom_components/jablotron_cloud/binary_sensor.py
+++ b/custom_components/jablotron_cloud/binary_sensor.py
@@ -24,6 +24,7 @@ async def async_setup_entry(
 ) -> None:
     """Register binary sensor entity for each Jablotron service uncontrollable programmable gate."""
 
+    _LOGGER.debug("Adding Jablotron binary sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
@@ -34,6 +35,7 @@ async def async_setup_entry(
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
+        _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
         gates = service_data["gates"]
         for gate in gates.get("programmableGates", []):
             gate: JablotronProgrammableGatesGate
@@ -46,6 +48,7 @@ async def async_setup_entry(
                 _LOGGER.debug("Programmable gate '%s' is controllable, ignoring!", gate_name)
                 continue
 
+            _LOGGER.debug("Adding uncontrollable programmable gate '%s' with initial state '%s'", gate_name, gate_state)
             entities.append(
                 JablotronProgrammableGate(
                     coordinator,
@@ -104,5 +107,6 @@ class JablotronProgrammableGate(JablotronEntity, BinarySensorEntity):
             _LOGGER.warning("No state available for gate '%s'!", self._gate_name)
             return
 
+        _LOGGER.debug("Gate '%s' received state '%s'", self._gate_name, gate_state)
         self._attr_is_on = pg_state_to_binary_state(gate_state)
         self.async_write_ha_state()

--- a/custom_components/jablotron_cloud/binary_sensor.py
+++ b/custom_components/jablotron_cloud/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import JablotronConfigEntry, JablotronData
+from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .entity import JablotronEntity
 from .utils import get_component_state, pg_state_to_binary_state
 
@@ -68,8 +68,8 @@ class JablotronProgrammableGate(JablotronEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        coordinator,
-        client,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
         service_name: str,
         service_type: str,

--- a/custom_components/jablotron_cloud/binary_sensor.py
+++ b/custom_components/jablotron_cloud/binary_sensor.py
@@ -8,12 +8,10 @@ from jablotronpy import JablotronProgrammableGatesGate
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
-from .const import DOMAIN
+from . import JablotronConfigEntry, JablotronData
+from .entity import JablotronEntity
 from .utils import get_component_state, pg_state_to_binary_state
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,38 +24,28 @@ async def async_setup_entry(
 ) -> None:
     """Register binary sensor entity for each Jablotron service uncontrollable programmable gate."""
 
-    _LOGGER.debug("Adding Jablotron binary sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get programmable gates for each service
     entities: list[JablotronProgrammableGate] = []
     for service_id, service_data in client.services.items():
-        # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
-        # Add all uncontrollable programmable gate entities
-        _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
         gates = service_data["gates"]
         for gate in gates.get("programmableGates", []):
-            # Get gate details
             gate: JablotronProgrammableGatesGate
             gate_name = gate["name"]
             gate_id = gate["cloud-component-id"]
             gate_state = get_component_state(gate_id, gates["states"])
             is_on = pg_state_to_binary_state(gate_state)
 
-            # Check whether programmable gate is NOT controllable
             if gate["can-control"]:
                 _LOGGER.debug("Programmable gate '%s' is controllable, ignoring!", gate_name)
-
                 continue
 
-            # Add uncontrollable programmable gate entity
-            _LOGGER.debug("Adding uncontrollable programmable gate '%s'", gate_name)
             entities.append(
                 JablotronProgrammableGate(
                     coordinator,
@@ -75,22 +63,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
-    """Unload binary sensor entities."""
-
-    return True
-
-
-class JablotronProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], BinarySensorEntity):
+class JablotronProgrammableGate(JablotronEntity, BinarySensorEntity):
     """Representation of Jablotron Cloud binary sensor entity."""
 
-    # Allow custom entity names
-    _attr_has_entity_name = True
-
     def __init__(
-        self: JablotronProgrammableGate,
-        coordinator: JablotronDataCoordinator,
-        client: JablotronClient,
+        self,
+        coordinator,
+        client,
         service_id: int,
         service_name: str,
         service_type: str,
@@ -100,65 +79,30 @@ class JablotronProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], Bin
         is_on: bool,
     ) -> None:
         """Initialize Jablotron binary sensor."""
-
-        # Define entity attributes
-        self._client = client
-        self._service_id = service_id
-        self._service_name = service_name
-        self._service_type = service_type
-        self._service_firmware = service_firmware
         self._gate_id = gate_id
         self._gate_name = gate_name
-
-        # Define sensor attributes
         self._attr_name = gate_name
         self._attr_unique_id = f"{service_id}_{gate_id}"
         self._attr_is_on = is_on
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
-        # Initialize binary sensor
-        super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about device."""
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, str(self._service_id))},
-            name=self._service_name,
-            manufacturer="Jablotron",
-            model=self._service_type,
-            sw_version=self._service_firmware,
-        )
-
-    # noinspection DuplicatedCode
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
-        # Get corresponding service data
-        _LOGGER.debug("Updating gate state for gate '%s'", self._gate_name)
         service = self._client.services.get(self._service_id, None)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
-
             return
 
-        # Get service states
         service_states = service["gates"]["states"]
         if not service_states:
             _LOGGER.warning("No states data available for service '%d'!", self._service_id)
-
             return
 
-        # Get gate state
         gate_state = get_component_state(self._gate_id, service_states)
         if not gate_state:
             _LOGGER.warning("No state available for gate '%s'!", self._gate_name)
-
             return
 
-        # Set current programmable gate state
         self._attr_is_on = pg_state_to_binary_state(gate_state)
         self.async_write_ha_state()
-
-        _LOGGER.debug("Successfully updated gate state for gate '%s'", self._gate_name)

--- a/custom_components/jablotron_cloud/climate.py
+++ b/custom_components/jablotron_cloud/climate.py
@@ -29,6 +29,7 @@ async def async_setup_entry(
 ) -> None:
     """Register climate entity for each Jablotron service thermo device."""
 
+    _LOGGER.debug("Adding Jablotron climate entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
@@ -39,6 +40,7 @@ async def async_setup_entry(
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
+        _LOGGER.debug("Getting available thermo devices for service '%s'", service_name)
         thermo_devices = service_data["thermo"]
         for thermo_device in thermo_devices:
             thermo_device_id = thermo_device["object-device-id"]
@@ -55,6 +57,13 @@ async def async_setup_entry(
             min_temp = thermo_state.get("temperature-range-min")
             max_temp = thermo_state.get("temperature-range-max")
 
+            _LOGGER.debug(
+                "Adding thermostat '%s' with initial mode '%s', current temp %s, target temp %s",
+                thermo_device_id,
+                heating_mode,
+                current_temperature,
+                target_temperature,
+            )
             entities.append(
                 JablotronClimate(
                     coordinator,
@@ -125,10 +134,18 @@ class JablotronClimate(JablotronEntity, ClimateEntity):
                 _LOGGER.warning("Unsupported HVAC mode: %s", hvac_mode)
                 return
 
+            _LOGGER.debug(
+                "Setting HVAC mode '%s' (heating_mode='%s') for device '%s' (service %d)",
+                hvac_mode,
+                heating_mode,
+                self._thermo_device_id,
+                self._service_id,
+            )
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
 
             # When turning on from OFF/STAND_BY, wake the device first before setting the actual mode
             if self._attr_hvac_mode == HVACMode.OFF and hvac_mode != HVACMode.OFF:
+                _LOGGER.debug("Waking thermo device '%s' before mode change", self._thermo_device_id)
                 wake_success = await self.hass.async_add_executor_job(
                     partial(
                         bridge.control_thermo_device,
@@ -174,6 +191,12 @@ class JablotronClimate(JablotronEntity, ClimateEntity):
             return
 
         try:
+            _LOGGER.debug(
+                "Setting temperature %.1f for device '%s' (service %d)",
+                temperature,
+                self._thermo_device_id,
+                self._service_id,
+            )
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             success = await self.hass.async_add_executor_job(
                 partial(
@@ -231,9 +254,17 @@ class JablotronClimate(JablotronEntity, ClimateEntity):
         self._attr_target_temperature = state.get("temperature-set")
 
         heating_mode = state.get("mode", "OFF")
-        self._attr_hvac_mode = THERMO_STATE_TO_HVAC_MODE.get(heating_mode, HVACMode.OFF)
-
         heating_state = state.get("heating-state", "HEATING_OFF")
+        _LOGGER.debug(
+            "Device '%s' received mode '%s', heating-state '%s', current temp %s, target temp %s",
+            self._thermo_device_id,
+            heating_mode,
+            heating_state,
+            self._attr_current_temperature,
+            self._attr_target_temperature,
+        )
+
+        self._attr_hvac_mode = THERMO_STATE_TO_HVAC_MODE.get(heating_mode, HVACMode.OFF)
         if self._attr_hvac_mode == HVACMode.OFF:
             self._attr_hvac_action = HVACAction.OFF
         elif heating_state == "HEATING":

--- a/custom_components/jablotron_cloud/climate.py
+++ b/custom_components/jablotron_cloud/climate.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import JablotronConfigEntry, JablotronData
+from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .const import DOMAIN, HVAC_MODE_TO_THERMO_STATE, THERMO_STATE_TO_HVAC_MODE
 from .entity import JablotronEntity
 from .utils import get_thermo_device
@@ -88,8 +88,8 @@ class JablotronClimate(JablotronEntity, ClimateEntity):
 
     def __init__(
         self,
-        coordinator,
-        client,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
         service_name: str,
         service_type: str,

--- a/custom_components/jablotron_cloud/climate.py
+++ b/custom_components/jablotron_cloud/climate.py
@@ -2,26 +2,22 @@
 
 from __future__ import annotations
 
-import logging
 from functools import partial
+import logging
 from typing import Any
 
-from homeassistant.components.climate import (
-    ClimateEntity,
-    ClimateEntityFeature,
-    HVACAction,
-    HVACMode,
-)
+from jablotronpy import UnauthorizedException
+
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature, HVACAction, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from jablotronpy import JablotronThermoDevice, UnauthorizedException
 
-from . import JablotronConfigEntry, JablotronData, JablotronDataCoordinator, JablotronClient
-from .const import DOMAIN, THERMO_STATE_TO_HVAC_MODE, HVAC_MODE_TO_THERMO_STATE
+from . import JablotronConfigEntry, JablotronData
+from .const import DOMAIN, HVAC_MODE_TO_THERMO_STATE, THERMO_STATE_TO_HVAC_MODE
+from .entity import JablotronEntity
+from .utils import get_thermo_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: JablotronConfigEntry,
-    async_add_entities: AddEntitiesCallback
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Register climate entity for each Jablotron service thermo device."""
 
@@ -37,17 +33,14 @@ async def async_setup_entry(
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get thermo devices for each service
     entities: list[JablotronClimate] = []
     for service_id, service_data in client.services.items():
-        # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
         thermo_devices = service_data["thermo"]
         for thermo_device in thermo_devices:
-            # Get thermo device details
             thermo_device_id = thermo_device["object-device-id"]
             thermo_state = thermo_device.get("thermo-device", {})
             state = thermo_device.get("state", {})
@@ -56,18 +49,14 @@ async def async_setup_entry(
             if not thermo_state.get("can-control", False):
                 continue
 
-            # Get temperature values
             current_temperature = thermo_device.get("temperature")
             target_temperature = state.get("temperature-set")
             heating_mode = state.get("mode", "OFF")
-
-            # Get temperature limits from thermo device settings
             min_temp = thermo_state.get("temperature-range-min")
             max_temp = thermo_state.get("temperature-range-max")
 
             entities.append(
                 JablotronClimate(
-                    hass,
                     coordinator,
                     client,
                     service_id,
@@ -79,22 +68,19 @@ async def async_setup_entry(
                     target_temperature,
                     heating_mode,
                     min_temp,
-                    max_temp
+                    max_temp,
                 )
             )
 
     async_add_entities(entities)
 
 
-class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntity):
+class JablotronClimate(JablotronEntity, ClimateEntity):
     """Representation of Jablotron Cloud climate entity."""
 
-    _attr_has_entity_name = True
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
-        ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-        | ClimateEntityFeature.TARGET_TEMPERATURE
+        ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TARGET_TEMPERATURE
     )
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO]
     _enable_turn_on_off_backwards_compat = False
@@ -102,9 +88,8 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
 
     def __init__(
         self,
-        hass: HomeAssistant,
-        coordinator: JablotronDataCoordinator,
-        client: JablotronClient,
+        coordinator,
+        client,
         service_id: int,
         service_name: str,
         service_type: str,
@@ -117,15 +102,7 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
         max_temp: float | None = None,
     ) -> None:
         """Initialize Jablotron climate entity."""
-
-        self._hass = hass
-        self._client = client
-        self._service_id = service_id
-        self._service_name = service_name
-        self._service_type = service_type
-        self._service_firmware = service_firmware
         self._thermo_device_id = thermo_device_id
-
         self._attr_name = f"{thermo_device_id}_climate"
         self._attr_unique_id = f"{service_id}_{thermo_device_id}_climate"
         self._attr_current_temperature = current_temperature
@@ -138,53 +115,40 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
         if max_temp is not None:
             self._attr_max_temp = max_temp
 
-        super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about device."""
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, str(self._service_id))},
-            name=self._service_name,
-            manufacturer="Jablotron",
-            model=self._service_type,
-            sw_version=self._service_firmware
-        )
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVAC mode."""
-
         try:
             heating_mode = HVAC_MODE_TO_THERMO_STATE.get(hvac_mode)
             if heating_mode is None:
                 _LOGGER.warning("Unsupported HVAC mode: %s", hvac_mode)
                 return
 
-            bridge = await self._hass.async_add_executor_job(self._client.get_bridge)
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
 
             # When turning on from OFF/STAND_BY, wake the device first before setting the actual mode
             if self._attr_hvac_mode == HVACMode.OFF and hvac_mode != HVACMode.OFF:
-                wake_success = await self._hass.async_add_executor_job(
+                wake_success = await self.hass.async_add_executor_job(
                     partial(
                         bridge.control_thermo_device,
                         service_id=self._service_id,
                         object_device_id=self._thermo_device_id,
                         heating_mode="ON",
-                        service_type=self._service_type
+                        service_type=self._service_type,
                     )
                 )
                 if not wake_success:
                     _LOGGER.error("Failed to wake thermo device '%s'", self._thermo_device_id)
                     return
 
-            success = await self._hass.async_add_executor_job(
+            success = await self.hass.async_add_executor_job(
                 partial(
                     bridge.control_thermo_device,
                     service_id=self._service_id,
                     object_device_id=self._thermo_device_id,
                     heating_mode=heating_mode,
-                    service_type=self._service_type
+                    service_type=self._service_type,
                 )
             )
 
@@ -196,29 +160,28 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except Exception as ex:
-            _LOGGER.exception("Failed to control thermo device '%s': %s", self._thermo_device_id, ex)
+            _LOGGER.exception("Failed to control thermo device '%s'", self._thermo_device_id)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="control_failed"
+                translation_key="control_failed",
             ) from ex
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             _LOGGER.warning("No temperature provided for set_temperature")
             return
 
         try:
-            bridge = await self._hass.async_add_executor_job(self._client.get_bridge)
-            success = await self._hass.async_add_executor_job(
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            success = await self.hass.async_add_executor_job(
                 partial(
                     bridge.control_thermo_device,
                     service_id=self._service_id,
                     object_device_id=self._thermo_device_id,
                     temperature=temperature,
-                    service_type=self._service_type
+                    service_type=self._service_type,
                 )
             )
 
@@ -230,10 +193,10 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except Exception as ex:
-            _LOGGER.exception("Failed to set temperature for thermo device '%s': %s", self._thermo_device_id, ex)
+            _LOGGER.exception("Failed to set temperature for thermo device '%s'", self._thermo_device_id)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="control_failed"
+                translation_key="control_failed",
             ) from ex
 
     async def async_turn_on(self) -> None:
@@ -247,41 +210,29 @@ class JablotronClimate(CoordinatorEntity[JablotronDataCoordinator], ClimateEntit
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
         service = self._client.services.get(self._service_id, None)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
             return
 
-        # Get service devices
         thermo_devices = service["thermo"]
         if not thermo_devices:
             _LOGGER.warning("No thermo devices available for service '%d'!", self._service_id)
             return
 
-        # Get device
-        thermo_device: JablotronThermoDevice | None = next(
-            filter(lambda device: device["object-device-id"] == self._thermo_device_id, thermo_devices),
-            None
-        )
+        thermo_device = get_thermo_device(self._thermo_device_id, thermo_devices)
         if not thermo_device:
             _LOGGER.warning("No thermo device found with id '%s'!", self._thermo_device_id)
             return
 
-        # Update current temperature
         self._attr_current_temperature = thermo_device.get("temperature")
 
-        # Get state data
         state = thermo_device.get("state", {})
-
-        # Update target temperature from state
         self._attr_target_temperature = state.get("temperature-set")
 
-        # Update HVAC mode from state mode
         heating_mode = state.get("mode", "OFF")
         self._attr_hvac_mode = THERMO_STATE_TO_HVAC_MODE.get(heating_mode, HVACMode.OFF)
 
-        # Check if heating is active
         heating_state = state.get("heating-state", "HEATING_OFF")
         if self._attr_hvac_mode == HVACMode.OFF:
             self._attr_hvac_action = HVACAction.OFF

--- a/custom_components/jablotron_cloud/entity.py
+++ b/custom_components/jablotron_cloud/entity.py
@@ -1,0 +1,41 @@
+"""Base entity for Jablotron Cloud integration."""
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import JablotronClient, JablotronDataCoordinator
+from .const import DOMAIN
+
+
+class JablotronEntity(CoordinatorEntity[JablotronDataCoordinator]):
+    """Base class for Jablotron Cloud entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
+        service_id: int,
+        service_name: str,
+        service_type: str,
+        service_firmware: str,
+    ) -> None:
+        """Initialize Jablotron entity."""
+        self._client = client
+        self._service_id = service_id
+        self._service_name = service_name
+        self._service_type = service_type
+        self._service_firmware = service_firmware
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information about device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._service_id))},
+            name=self._service_name,
+            manufacturer="Jablotron",
+            model=self._service_type,
+            sw_version=self._service_firmware,
+        )

--- a/custom_components/jablotron_cloud/manifest.json
+++ b/custom_components/jablotron_cloud/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "jablotronpy==0.7.3"
     ],
-    "version": "0.7.0"
+    "version": "0.7.1"
 }

--- a/custom_components/jablotron_cloud/sensor.py
+++ b/custom_components/jablotron_cloud/sensor.py
@@ -23,6 +23,7 @@ async def async_setup_entry(
 ) -> None:
     """Register sensor entity for each Jablotron service thermo device."""
 
+    _LOGGER.debug("Adding Jablotron sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
@@ -33,6 +34,7 @@ async def async_setup_entry(
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
+        _LOGGER.debug("Getting available thermo devices for service '%s'", service_name)
         thermo_devices = service_data["thermo"]
         for thermo_device in thermo_devices:
             # Skip controllable thermo devices — handled by the climate platform
@@ -42,6 +44,9 @@ async def async_setup_entry(
             thermo_device_id = thermo_device["object-device-id"]
             current_temperature = thermo_device["temperature"]
 
+            _LOGGER.debug(
+                "Adding thermo device '%s' with initial temperature %s", thermo_device_id, current_temperature
+            )
             entities.append(
                 JablotronSensor(
                     coordinator,
@@ -101,5 +106,7 @@ class JablotronSensor(JablotronEntity, SensorEntity):
             _LOGGER.warning("No thermo device found with id '%s'!", self._thermo_device_id)
             return
 
-        self._attr_native_value = thermo_device["temperature"]
+        temperature = thermo_device["temperature"]
+        _LOGGER.debug("Device '%s' received temperature %s", self._thermo_device_id, temperature)
+        self._attr_native_value = temperature
         self.async_write_ha_state()

--- a/custom_components/jablotron_cloud/sensor.py
+++ b/custom_components/jablotron_cloud/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import JablotronConfigEntry, JablotronData
+from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .entity import JablotronEntity
 from .utils import get_thermo_device
 
@@ -67,8 +67,8 @@ class JablotronSensor(JablotronEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator,
-        client,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
         service_name: str,
         service_type: str,

--- a/custom_components/jablotron_cloud/sensor.py
+++ b/custom_components/jablotron_cloud/sensor.py
@@ -4,17 +4,14 @@ from __future__ import annotations
 
 import logging
 
-from jablotronpy import JablotronThermoDevice
-
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
-from .const import DOMAIN
+from . import JablotronConfigEntry, JablotronData
+from .entity import JablotronEntity
+from .utils import get_thermo_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,33 +23,25 @@ async def async_setup_entry(
 ) -> None:
     """Register sensor entity for each Jablotron service thermo device."""
 
-    _LOGGER.debug("Adding Jablotron sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get thermo devices for each service
     entities: list[JablotronSensor] = []
     for service_id, service_data in client.services.items():
-        # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
-        # Add all thermo device entities
-        _LOGGER.debug("Getting available thermo devices for service '%s'", service_name)
         thermo_devices = service_data["thermo"]
         for thermo_device in thermo_devices:
             # Skip controllable thermo devices — handled by the climate platform
             if thermo_device.get("thermo-device", {}).get("can-control", False):
                 continue
 
-            # Get thermo device details
             thermo_device_id = thermo_device["object-device-id"]
             current_temperature = thermo_device["temperature"]
 
-            # Add thermo device entity
-            _LOGGER.debug("Adding thermo device '%s'", thermo_device_id)
             entities.append(
                 JablotronSensor(
                     coordinator,
@@ -69,25 +58,17 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
-    """Unload sensor entities."""
-
-    return True
-
-
-class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity):
+class JablotronSensor(JablotronEntity, SensorEntity):
     """Representation of Jablotron Cloud sensor entity."""
 
-    # Allow custom entity names
-    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     def __init__(
-        self: JablotronSensor,
-        coordinator: JablotronDataCoordinator,
-        client: JablotronClient,
+        self,
+        coordinator,
+        client,
         service_id: int,
         service_name: str,
         service_type: str,
@@ -96,72 +77,29 @@ class JablotronSensor(CoordinatorEntity[JablotronDataCoordinator], SensorEntity)
         current_temperature: float,
     ) -> None:
         """Initialize Jablotron sensor."""
-
-        # Define entity attributes
-        self._client = client
-        self._service_id = service_id
-        self._service_name = service_name
-        self._service_type = service_type
-        self._service_firmware = service_firmware
         self._thermo_device_id = thermo_device_id
-
-        # Define sensor attributes
         self._attr_name = f"{thermo_device_id}_temperature"
         self._attr_unique_id = f"{service_id}_{thermo_device_id}"
         self._attr_native_value = current_temperature
-
-        # Initialize sensor
-        super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about device."""
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, str(self._service_id))},
-            name=self._service_name,
-            manufacturer="Jablotron",
-            model=self._service_type,
-            sw_version=self._service_firmware,
-        )
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
-        # Get corresponding service data
-        _LOGGER.debug("Updating thermo device state for device '%s'", self._thermo_device_id)
         service = self._client.services.get(self._service_id, None)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
-
             return
 
-        # Get service devices
         thermo_devices = service["thermo"]
         if not thermo_devices:
             _LOGGER.warning("No thermo devices available for service '%d'!", self._service_id)
-
             return
 
-        # Get device
-        thermo_device: JablotronThermoDevice | None = next(
-            filter(
-                lambda device: device["object-device-id"] == self._thermo_device_id,
-                thermo_devices,
-            ),
-            None,
-        )
+        thermo_device = get_thermo_device(self._thermo_device_id, thermo_devices)
         if not thermo_device:
             _LOGGER.warning("No thermo device found with id '%s'!", self._thermo_device_id)
-
             return
 
-        # Set current thermo device state
         self._attr_native_value = thermo_device["temperature"]
         self.async_write_ha_state()
-
-        _LOGGER.debug(
-            "Successfully updated thermo device state for device '%s'",
-            self._thermo_device_id,
-        )

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import JablotronConfigEntry, JablotronData
+from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .const import DOMAIN
 from .entity import JablotronEntity
 from .utils import get_component_state, pg_state_to_binary_state
@@ -74,8 +74,8 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator,
-        client,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
         service_id: int,
         service_name: str,
         service_type: str,

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -28,6 +28,7 @@ async def async_setup_entry(
 ) -> None:
     """Register switch entity for each Jablotron service controllable programmable gate."""
 
+    _LOGGER.debug("Adding Jablotron switch entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
@@ -38,6 +39,7 @@ async def async_setup_entry(
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
+        _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
         gates = service_data["gates"]
         for gate in gates.get("programmableGates", []):
             gate: JablotronProgrammableGatesGate
@@ -50,6 +52,7 @@ async def async_setup_entry(
                 _LOGGER.debug("Programmable gate '%s' is uncontrollable, ignoring!", gate_name)
                 continue
 
+            _LOGGER.debug("Adding controllable programmable gate '%s' with initial state '%s'", gate_name, gate_state)
             entities.append(
                 JablotronProgrammableGate(
                     coordinator,
@@ -95,6 +98,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send turn on request."""
         try:
+            _LOGGER.debug("Sending turn on for gate '%s' (service %d)", self._gate_name, self._service_id)
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             turn_on_successful = await self.hass.async_add_executor_job(
                 partial(
@@ -116,6 +120,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send turn off request."""
         try:
+            _LOGGER.debug("Sending turn off for gate '%s' (service %d)", self._gate_name, self._service_id)
             bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
             turn_off_successful = await self.hass.async_add_executor_job(
                 partial(
@@ -152,5 +157,6 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
             _LOGGER.warning("No state available for gate '%s'!", self._gate_name)
             return
 
+        _LOGGER.debug("Gate '%s' received state '%s'", self._gate_name, gate_state)
         self._attr_is_on = pg_state_to_binary_state(gate_state)
         self.async_write_ha_state()

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
+from functools import partial
 import logging
+from typing import Any
 
 from jablotronpy import IncorrectPinCodeException, JablotronProgrammableGatesGate, UnauthorizedException
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
+from . import JablotronConfigEntry, JablotronData
 from .const import DOMAIN
+from .entity import JablotronEntity
 from .utils import get_component_state, pg_state_to_binary_state
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,38 +28,28 @@ async def async_setup_entry(
 ) -> None:
     """Register switch entity for each Jablotron service controllable programmable gate."""
 
-    _LOGGER.debug("Adding Jablotron switch entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    # Get programmable gates for each service
     entities: list[JablotronProgrammableGate] = []
     for service_id, service_data in client.services.items():
-        # Get service details
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
 
-        # Add all controllable programmable gate entities
-        _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
         gates = service_data["gates"]
         for gate in gates.get("programmableGates", []):
-            # Get gate details
             gate: JablotronProgrammableGatesGate
             gate_name = gate["name"]
             gate_id = gate["cloud-component-id"]
             gate_state = get_component_state(gate_id, gates["states"])
             is_on = pg_state_to_binary_state(gate_state)
 
-            # Check whether programmable gate is controllable
             if not gate["can-control"]:
                 _LOGGER.debug("Programmable gate '%s' is uncontrollable, ignoring!", gate_name)
-
                 continue
 
-            # Add controllable programmable gate entity
-            _LOGGER.debug("Adding controllable programmable gate '%s'", gate_name)
             entities.append(
                 JablotronProgrammableGate(
                     coordinator,
@@ -76,23 +67,15 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
-    """Unload switch entities."""
-
-    return True
-
-
-class JablotronProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], SwitchEntity):
+class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
     """Representation of Jablotron Cloud switch entity."""
 
-    # Allow custom entity names
-    _attr_has_entity_name = True
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     def __init__(
-        self: JablotronProgrammableGate,
-        coordinator: JablotronDataCoordinator,
-        client: JablotronClient,
+        self,
+        coordinator,
+        client,
         service_id: int,
         service_name: str,
         service_type: str,
@@ -102,109 +85,72 @@ class JablotronProgrammableGate(CoordinatorEntity[JablotronDataCoordinator], Swi
         is_on: bool,
     ) -> None:
         """Initialize Jablotron switch."""
-
-        # Define entity attributes
-        self._client = client
-        self._service_id = service_id
-        self._service_name = service_name
-        self._service_type = service_type
-        self._service_firmware = service_firmware
         self._gate_id = gate_id
         self._gate_name = gate_name
-
-        # Define switch attributes
         self._attr_name = gate_name
         self._attr_unique_id = f"{service_id}_{gate_id}"
         self._attr_is_on = is_on
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
-        # Initialize switch
-        super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about device."""
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, str(self._service_id))},
-            name=self._service_name,
-            manufacturer="Jablotron",
-            model=self._service_type,
-            sw_version=self._service_firmware,
-        )
-
-    def turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Send turn on request."""
-
         try:
-            # Send turn on request to gate
-            bridge = self._client.get_bridge()
-            turn_on_successful = bridge.control_programmable_gate(
-                service_id=self._service_id,
-                service_type=self._service_type,
-                component_id=self._gate_id,
-                state="ON",
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            turn_on_successful = await self.hass.async_add_executor_job(
+                partial(
+                    bridge.control_programmable_gate,
+                    service_id=self._service_id,
+                    service_type=self._service_type,
+                    component_id=self._gate_id,
+                    state="ON",
+                )
             )
-
-            # Set state to on if turn on action was successful
             if turn_on_successful:
                 self._attr_is_on = True
-                self.schedule_update_ha_state()
+                self.async_write_ha_state()
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin")
+        except IncorrectPinCodeException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
-    def turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Send turn off request."""
-
         try:
-            # Send turn off request to gate
-            bridge = self._client.get_bridge()
-            turn_off_successful = bridge.control_programmable_gate(
-                service_id=self._service_id,
-                service_type=self._service_type,
-                component_id=self._gate_id,
-                state="OFF",
+            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+            turn_off_successful = await self.hass.async_add_executor_job(
+                partial(
+                    bridge.control_programmable_gate,
+                    service_id=self._service_id,
+                    service_type=self._service_type,
+                    component_id=self._gate_id,
+                    state="OFF",
+                )
             )
-
-            # Set state to off if turn off action was successful
             if turn_off_successful:
                 self._attr_is_on = False
-                self.schedule_update_ha_state()
+                self.async_write_ha_state()
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin")
+        except IncorrectPinCodeException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
-    # noinspection DuplicatedCode
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
-
-        # Get corresponding service data
-        _LOGGER.debug("Updating gate state for gate '%s'", self._gate_name)
         service = self._client.services.get(self._service_id, None)
         if not service:
             _LOGGER.error("No data available for service '%d'!", self._service_id)
-
             return
 
-        # Get service states
         service_states = service["gates"]["states"]
         if not service_states:
             _LOGGER.warning("No states data available for service '%d'!", self._service_id)
-
             return
 
-        # Get gate state
         gate_state = get_component_state(self._gate_id, service_states)
         if not gate_state:
             _LOGGER.warning("No state available for gate '%s'!", self._gate_name)
-
             return
 
-        # Set current programmable gate state
         self._attr_is_on = pg_state_to_binary_state(gate_state)
         self.async_write_ha_state()
-
-        _LOGGER.debug("Successfully updated gate state for gate '%s'", self._gate_name)

--- a/custom_components/jablotron_cloud/utils.py
+++ b/custom_components/jablotron_cloud/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from jablotronpy import JablotronProgrammableGatesState, JablotronSectionsState
+from jablotronpy import JablotronProgrammableGatesState, JablotronSectionsState, JablotronThermoDevice
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.const import STATE_UNKNOWN
@@ -54,3 +54,15 @@ def pg_state_to_binary_state(state: str | None) -> bool:
     """Convert programmable gate state to boolean value."""
 
     return PG_STATE_AS_BINARY_STATE.get(state, False)
+
+
+def get_thermo_device(
+    device_id: str,
+    devices: list[JablotronThermoDevice],
+) -> JablotronThermoDevice | None:
+    """Return Jablotron thermo device by ID."""
+
+    return next(
+        filter(lambda device: device["object-device-id"] == device_id, devices),
+        None,
+    )


### PR DESCRIPTION
## Summary
- Extract `JablotronEntity` base class (`entity.py`) to eliminate duplicated `device_info`, instance variables, and `has_entity_name` across all 5 entity platforms
- Convert alarm_control_panel and switch to async control methods with `async_write_ha_state()`
- Remove no-op `async_unload_entry` from platform files
- Fix HA guideline violations: remove `hass` constructor param in climate, add `raise from` chains, add `**kwargs: Any` typing
- Add `get_thermo_device()` utility to replace duplicated lookup pattern
- Bump version to 0.7.1

## Test plan
- [ ] Verify alarm control panel arm/disarm/partial arm still works
- [ ] Verify switch on/off still works
- [ ] Verify climate HVAC mode and temperature control still works
- [ ] Verify binary sensor and sensor state updates from coordinator
- [ ] Run `ruff check` and `ruff format --check` with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)