### PR TITLE
Fix TimeoutError handling and supported_features property

### DIFF
--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -246,6 +246,3 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                     )
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
-        except TimeoutError:
-            # Warn that timeout occurred that will cause data to not be up-to-date
-            _LOGGER.warning("Timeout while updating data for available services, data may be out of date!")

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -102,6 +102,10 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         self._supports_partial_arm = partial_arm_enabled
         self._authorization_required = requires_authorization
         self._attr_alarm_state = current_state
+        # Set supported features once during initialization
+        self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+        if partial_arm_enabled:
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
         super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
 
     @property
@@ -113,14 +117,6 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
     def code_arm_required(self) -> bool:
         """Whether code is required for arm actions."""
         return self._authorization_required
-
-    @property
-    def supported_features(self) -> AlarmControlPanelEntityFeature:
-        """Return list of supported features."""
-        supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
-        if self._supports_partial_arm:
-            supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-        return supported_features
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm request."""

--- a/custom_components/jablotron_cloud/manifest.json
+++ b/custom_components/jablotron_cloud/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "jablotronpy==0.7.3"
     ],
-    "version": "0.7.1"
+    "version": "0.8.1"
 }


### PR DESCRIPTION
## Summary
- Fix TimeoutError handling: handling removed as it is handled by the coordinator and we do not want to messa up with the default behavior
- Refactor supported_features: Move from unnecessary @property to static _attr_supported_features set in __init__ per CLAUDE.md guidelines

## Details
**supported_features**: The property was computing a static value based only on initialization parameters that never change. Refactored to use _attr_supported_features attribute set once in __init__, following the CLAUDE.md guideline: "Use _attr_ for static/simple values; use @property only when logic is needed."

## Testing
- Verify TimeoutError causes entity unavailability in Home Assistant
- Confirm alarm control panel shows correct supported features
