### PR TITLE
Fix issue #56: Add missing pin_code parameter to programmable gate control

### DIFF
--- a/custom_components/jablotron_cloud/jablotron.py
+++ b/custom_components/jablotron_cloud/jablotron.py
@@ -31,3 +31,8 @@ class JablotronClient:
         bridge.perform_login()
 
         return bridge
+
+    def get_default_pin(self) -> str | None:
+        """Return the default PIN code."""
+
+        return self._default_pin

--- a/custom_components/jablotron_cloud/strings.json
+++ b/custom_components/jablotron_cloud/strings.json
@@ -49,6 +49,9 @@
         },
         "control_failed": {
             "message": "Failed to control thermo device!"
+        },
+        "switch_control_failed": {
+            "message": "Failed to control programmable gate!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -6,7 +6,7 @@ from functools import partial
 import logging
 from typing import Any
 
-from jablotronpy import IncorrectPinCodeException, JablotronProgrammableGatesGate, UnauthorizedException
+from jablotronpy import BadRequestException, IncorrectPinCodeException, JablotronProgrammableGatesGate, UnauthorizedException
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
@@ -107,6 +107,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
                     service_type=self._service_type,
                     component_id=self._gate_id,
                     state="ON",
+                    pin_code=self._client._default_pin,
                 )
             )
             if turn_on_successful:
@@ -116,6 +117,8 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
+        except BadRequestException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="switch_control_failed") from ex
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send turn off request."""
@@ -129,6 +132,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
                     service_type=self._service_type,
                     component_id=self._gate_id,
                     state="OFF",
+                    pin_code=self._client._default_pin,
                 )
             )
             if turn_off_successful:
@@ -138,6 +142,8 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
+        except BadRequestException as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="switch_control_failed") from ex
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/jablotron_cloud/switch.py
+++ b/custom_components/jablotron_cloud/switch.py
@@ -6,7 +6,12 @@ from functools import partial
 import logging
 from typing import Any
 
-from jablotronpy import BadRequestException, IncorrectPinCodeException, JablotronProgrammableGatesGate, UnauthorizedException
+from jablotronpy import (
+    BadRequestException,
+    IncorrectPinCodeException,
+    JablotronProgrammableGatesGate,
+    UnauthorizedException,
+)
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
@@ -107,7 +112,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
                     service_type=self._service_type,
                     component_id=self._gate_id,
                     state="ON",
-                    pin_code=self._client._default_pin,
+                    pin_code=self._client.get_default_pin(),
                 )
             )
             if turn_on_successful:
@@ -132,7 +137,7 @@ class JablotronProgrammableGate(JablotronEntity, SwitchEntity):
                     service_type=self._service_type,
                     component_id=self._gate_id,
                     state="OFF",
-                    pin_code=self._client._default_pin,
+                    pin_code=self._client.get_default_pin(),
                 )
             )
             if turn_off_successful:

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -49,6 +49,9 @@
         },
         "control_failed": {
             "message": "Nepodařilo se ovládat termo zařízení!"
+        },
+        "switch_control_failed": {
+            "message": "Nepodařilo se ovládat programovatelnou bránu!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/en.json
+++ b/custom_components/jablotron_cloud/translations/en.json
@@ -49,6 +49,9 @@
         },
         "control_failed": {
             "message": "Failed to control thermo device!"
+        },
+        "switch_control_failed": {
+            "message": "Failed to control programmable gate!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/nl.json
+++ b/custom_components/jablotron_cloud/translations/nl.json
@@ -49,6 +49,9 @@
         },
         "control_failed": {
             "message": "Kan het thermo-apparaat niet bedienen!"
+        },
+        "switch_control_failed": {
+            "message": "Kan de programmeerbare poort niet bedienen!"
         }
     }
 }

--- a/custom_components/jablotron_cloud/translations/sk.json
+++ b/custom_components/jablotron_cloud/translations/sk.json
@@ -49,6 +49,9 @@
         },
         "control_failed": {
             "message": "Nepodarilo sa ovládať termo zariadenie!"
+        },
+        "switch_control_failed": {
+            "message": "Nepodarilo sa ovládať programovateľnú bránu!"
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes the BadRequestException that occurs when attempting to control PG switches by adding the required `pin_code` parameter to the `control_programmable_gate` method calls.

The jablotronpy library requires this parameter, which was missing from the implementation. This fix allows users to properly control their programmable gates via Home Assistant.

## Changes
- Add `pin_code` parameter to `async_turn_on` and `async_turn_off` methods in switch.py
- Add proper error handling for `BadRequestException` with user-friendly error messages
- Add new `switch_control_failed` translation key for all supported languages (English, Czech, Slovak, Dutch)

## Test plan
- Verify PG switches can now be controlled without BadRequestException
- Confirm error messages display correctly in all supported languages when control fails
- Check that existing alarm control panel and climate functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)