### PR TITLE
Add Ruff linting GitHub Actions workflow

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,14 @@
+name: Ruff
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check custom_components/"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ruff.yaml` using the official `astral-sh/ruff-action`
- Runs `ruff check custom_components/` on every push and pull request

## Enabling PR blocking
To block merging until Ruff passes, enable a branch protection rule on `main`:
1. **Settings → Branches → Add rule** for `main`
2. Enable **"Require status checks to pass before merging"**
3. Add **`ruff`** as a required check

🤖 Generated with [Claude Code](https://claude.com/claude-code)