### PR TITLE
Add alarm-triggered state detection for alarm_control_panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ecosystem:
 
 | Entity type           | Description                                                     |
 |-----------------------|-----------------------------------------------------------------|
-| `alarm_control_panel` | Used for monitoring and controlling alarm sections              |
+| `alarm_control_panel` | Used for monitoring and controlling alarm sections (including `triggered` state when an alarm is active) |
 | `binary_sensor`       | Used for monitoring **UN**controllable programmable gates (PGs) |
 | `climate`             | Used for controlling thermo devices (thermostats)               |
 | `switch`              | Used for controlling programmable gates (PGs)                   |
@@ -71,6 +71,47 @@ The integration allows you to modify the following parameters:
 * Frequency of polling data from Jablotron Cloud
 * Timeout for polling data from Jablotron Cloud
 
-## Missing functionality
+## Alarm event detection
 
-* Integration does not listen for active alarms **- this is limitation of Jablotron Cloud API**
+The integration surfaces an active alarm by flipping the affected `alarm_control_panel` entity to the
+`triggered` state. Detection is **per section** — when an alarm is in progress, the Jablotron Cloud API
+returns an event with a message such as `"Alarm - Periphery PIR chodba (wifi), Section Dům"`. The
+integration parses the section name from the substring after the `, Section ` token and only the matching
+section is reported as `triggered`. Other sections of the same service stay in their previous state.
+
+While a section is `triggered`, its entity exposes the following extra attributes describing the latest
+matching event:
+
+| Attribute            | Description                                                          |
+|----------------------|----------------------------------------------------------------------|
+| `last_alarm_type`    | Event type as reported by the cloud (currently always `ALARM`)       |
+| `last_alarm_message` | Human-readable description, e.g. detector and section that triggered |
+| `last_alarm_date`    | ISO 8601 timestamp when the event was raised                         |
+
+Example automation that fires whenever any alarm panel is triggered:
+
+```yaml
+- alias: Jablotron alarm triggered
+  trigger:
+    - platform: state
+      entity_id: alarm_control_panel.dum
+      to: "triggered"
+  action:
+    - service: notify.mobile_app
+      data:
+        title: "Alarm!"
+        message: "{{ state_attr(trigger.entity_id, 'last_alarm_message') }}"
+```
+
+### Caveats
+
+* **Polling-based detection.** The Jablotron Cloud API does not push notifications. The integration only
+  knows about an alarm while the cloud response still contains the active event. If the alarm is silenced
+  before the next poll, the trigger is missed. For time-critical automations consider lowering the
+  `Frequency of polling` setting (minimum 5 seconds).
+* **Message format dependency.** Section identification relies on the message ending with
+  `, Section <name>` where `<name>` matches the configured section name exactly. If your panel firmware
+  emits ALARM events without that suffix, the entity will not flip to `triggered`. Please open an issue
+  with a redacted log sample if you observe this.
+* **Historical events are not used.** The cloud-side event history endpoint (`eventHistoryGet`) returns
+  `400 METHOD.NOT-SUPPORTED` on several panel models (e.g. JA100F), so it is not relied on as a fallback.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Example automation that fires whenever any alarm panel is triggered:
 * **Polling-based detection.** The Jablotron Cloud API does not push notifications. The integration only
   knows about an alarm while the cloud response still contains the active event. If the alarm is silenced
   before the next poll, the trigger is missed. For time-critical automations consider lowering the
-  `Frequency of polling` setting (minimum 5 seconds).
+  `Frequency of polling` setting (minimum 30 seconds).
 * **Message format dependency.** Section identification relies on the message ending with
   `, Section <name>` where `<name>` matches the configured section name exactly. If your panel firmware
   emits ALARM events without that suffix, the entity will not flip to `triggered`. Please open an issue

--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ Example automation that fires whenever any alarm panel is triggered:
   with a redacted log sample if you observe this.
 * **Historical events are not used.** The cloud-side event history endpoint (`eventHistoryGet`) returns
   `400 METHOD.NOT-SUPPORTED` on several panel models (e.g. JA100F), so it is not relied on as a fallback.
+
+# Support
+
+![Buy me a coffee QR](https://github.com/Pigotka/ha-cc-jablotron-cloud/blob/main/bmc_qr.png)

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 import logging
+from typing import Any
 
 from jablotronpy import IncorrectPinCodeException, UnauthorizedException
 
@@ -20,7 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
 from .const import DOMAIN
 from .entity import JablotronEntity
-from .utils import get_component_state, section_state_to_alarm_state
+from .utils import find_section_alarm_event, get_component_state, section_state_to_alarm_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,14 +51,17 @@ async def async_setup_entry(
             section_id = section["cloud-component-id"]
             partial_arm_enabled = section["partial-arm-enabled"]
             requires_authorization = section["need-authorization"]
-            section_state = get_component_state(section_id, alarm["states"])
-            current_state = section_state_to_alarm_state(section_state)
-
             if not section["can-control"]:
                 _LOGGER.debug("Section '%s' is not controllable, ignoring!", section_name)
                 continue
 
-            _LOGGER.debug("Adding controllable section '%s' with initial state '%s'", section_name, section_state)
+            if find_section_alarm_event(alarm, section_name) is not None:
+                current_state = AlarmControlPanelState.TRIGGERED
+            else:
+                section_state = get_component_state(section_id, alarm["states"])
+                current_state = section_state_to_alarm_state(section_state)
+
+            _LOGGER.debug("Adding controllable section '%s' with initial state '%s'", section_name, current_state)
             entities.append(
                 JablotronAlarmControlPanel(
                     coordinator,
@@ -205,6 +209,23 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         except IncorrectPinCodeException as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the matching alarm event details while this section is triggered."""
+        service = self._client.services.get(self._service_id)
+        if not service:
+            return None
+
+        event = find_section_alarm_event(service["alarm"], self._section_name)
+        if event is None:
+            return None
+
+        return {
+            "last_alarm_date": event.get("date"),
+            "last_alarm_message": event.get("message"),
+            "last_alarm_type": event.get("type"),
+        }
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
@@ -213,7 +234,15 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
             _LOGGER.error("No data available for service '%d'!", self._service_id)
             return
 
-        service_states = service["alarm"]["states"]
+        alarm = service["alarm"]
+        event = find_section_alarm_event(alarm, self._section_name)
+        if event is not None:
+            _LOGGER.debug("Section '%s' triggered: %s", self._section_name, event.get("message"))
+            self._attr_alarm_state = AlarmControlPanelState.TRIGGERED
+            self.async_write_ha_state()
+            return
+
+        service_states = alarm["states"]
         if not service_states:
             _LOGGER.warning("No states data available for service '%d'!", self._service_id)
             return

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from functools import partial
 import logging
-from typing import Any
 
 from jablotronpy import IncorrectPinCodeException, UnauthorizedException
 
@@ -106,6 +105,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         self._supports_partial_arm = partial_arm_enabled
         self._authorization_required = requires_authorization
         self._attr_alarm_state = current_state
+        self._attr_extra_state_attributes = None
         # Set supported features once during initialization
         self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
         if partial_arm_enabled:
@@ -209,23 +209,6 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         except IncorrectPinCodeException as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Expose the matching alarm event details while this section is triggered."""
-        service = self._client.services.get(self._service_id)
-        if not service:
-            return None
-
-        event = find_section_alarm_event(service["alarm"], self._section_name)
-        if event is None:
-            return None
-
-        return {
-            "last_alarm_date": event.get("date"),
-            "last_alarm_message": event.get("message"),
-            "last_alarm_type": event.get("type"),
-        }
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Process data retrieved by coordinator."""
@@ -239,8 +222,15 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         if event is not None:
             _LOGGER.debug("Section '%s' triggered: %s", self._section_name, event.get("message"))
             self._attr_alarm_state = AlarmControlPanelState.TRIGGERED
+            self._attr_extra_state_attributes = {
+                "last_alarm_date": event.get("date"),
+                "last_alarm_message": event.get("message"),
+                "last_alarm_type": event.get("type"),
+            }
             self.async_write_ha_state()
             return
+
+        self._attr_extra_state_attributes = None
 
         service_states = alarm["states"]
         if not service_states:

--- a/custom_components/jablotron_cloud/const.py
+++ b/custom_components/jablotron_cloud/const.py
@@ -5,6 +5,7 @@ from homeassistant.components.climate import HVACMode
 from homeassistant.const import Platform
 
 # Integration constants
+ALARM_EVENT_TYPE = "ALARM"
 DOMAIN = "jablotron_cloud"
 UNSUPPORTED_SERVICES = ["FUTURA2", "AMBIENTA", "VOLTA", "LOGBOOK"]
 PLATFORMS: list[Platform] = [

--- a/custom_components/jablotron_cloud/utils.py
+++ b/custom_components/jablotron_cloud/utils.py
@@ -2,16 +2,23 @@
 
 import logging
 
-from jablotronpy import JablotronProgrammableGatesState, JablotronSectionsState, JablotronThermoDevice
+from jablotronpy import (
+    JablotronProgrammableGatesState,
+    JablotronSections,
+    JablotronSectionsState,
+    JablotronThermoDevice,
+)
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.helpers.entity_registry import RegistryEntry
 
-from .const import PG_STATE_AS_BINARY_STATE, SECTION_STATE_AS_ALARM_STATE
+from .const import ALARM_EVENT_TYPE, PG_STATE_AS_BINARY_STATE, SECTION_STATE_AS_ALARM_STATE
 
 _LOGGER = logging.getLogger(__name__)
+
+SECTION_TOKEN = ", Section "
 
 
 @callback
@@ -54,6 +61,29 @@ def pg_state_to_binary_state(state: str | None) -> bool:
     """Convert programmable gate state to boolean value."""
 
     return PG_STATE_AS_BINARY_STATE.get(state, False)
+
+
+def get_service_alarm_events(alarm: JablotronSections) -> list[dict]:
+    """Return active service-level events from sections payload, or empty list."""
+
+    return alarm.get("service-states", {}).get("events", []) or []
+
+
+def find_section_alarm_event(alarm: JablotronSections, section_name: str) -> dict | None:
+    """Return the most recent ALARM event whose message references the given section, or None.
+
+    The Jablotron event message format is 'Alarm - <detector>, Section <section name>'.
+    The section is identified by the substring after the literal ', Section ' token.
+    """
+
+    matches = [
+        event
+        for event in get_service_alarm_events(alarm)
+        if event.get("type") == ALARM_EVENT_TYPE
+        and event.get("message", "").rsplit(SECTION_TOKEN, 1)[-1].strip() == section_name
+    ]
+
+    return matches[-1] if matches else None
 
 
 def get_thermo_device(


### PR DESCRIPTION
Surface the `triggered` Home Assistant alarm state on each section by parsing service-states.events from the get_sections response. The event message format `Alarm - <detector>, Section <name>` lets us match an event to the section that fired, so only the affected entity flips to `triggered`. Latest event details are exposed via extra_state_attributes (last_alarm_type, last_alarm_message, last_alarm_date) for use in automations.