### PR TITLE
Fix security audit findings: data isolation, PIN exposure, action timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -66,7 +66,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: JablotronConfigEntry) ->
 async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -> bool:
     """Unload Jablotron Cloud integration."""
 
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        # Drop cached service data so a reload starts from a clean state.
+        entry.runtime_data.client.services.clear()
+    return unload_ok
 
 
 async def update_listener(hass: HomeAssistant, entry: JablotronConfigEntry) -> None:
@@ -132,7 +136,7 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
 
         # Define coordinator attributes
         self._client = client
-        self._scan_timeout = scan_timeout
+        self.scan_timeout = scan_timeout
 
         # Initialize data update coordinator
         super().__init__(
@@ -212,7 +216,7 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
 
         try:
             # Update data within a certain time limit
-            async with timeout(self._scan_timeout):
+            async with timeout(self.scan_timeout):
                 # Get fresh Jablotron Cloud session
                 _LOGGER.debug("Updating data for available Jablotron services")
                 bridge: Jablotron = await self.hass.async_add_executor_job(self._client.get_bridge)

--- a/custom_components/jablotron_cloud/__init__.py
+++ b/custom_components/jablotron_cloud/__init__.py
@@ -68,7 +68,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: JablotronConfigEntry) -
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        # Drop cached service data so a reload starts from a clean state.
+        # Stop scheduled refreshes, then drop cached service data so a reload starts from a clean state.
+        await entry.runtime_data.coordinator.async_shutdown()
         entry.runtime_data.client.services.clear()
     return unload_ok
 
@@ -222,25 +223,27 @@ class JablotronDataCoordinator(DataUpdateCoordinator):
                 bridge: Jablotron = await self.hass.async_add_executor_job(self._client.get_bridge)
 
                 # Update data for all available services
-                for service_id in self._client.services:
+                # Iterate over a snapshot and mutate via local reference so an unload clearing
+                # the services dict mid-refresh cannot break the loop.
+                for service_id, service_data in list(self._client.services.items()):
                     # Get service details
-                    service_type = self._client.services[service_id]["type"]
+                    service_type = service_data["type"]
 
                     # Update sections data from Jablotron Cloud
                     _LOGGER.debug("Updating sections data for service '%d'", service_id)
-                    self._client.services[service_id]["alarm"] = await self.hass.async_add_executor_job(
+                    service_data["alarm"] = await self.hass.async_add_executor_job(
                         bridge.get_sections, service_id, service_type
                     )
 
                     # Update gates data from Jablotron Cloud
                     _LOGGER.debug("Updating gates data for service '%d'", service_id)
-                    self._client.services[service_id]["gates"] = await self.hass.async_add_executor_job(
+                    service_data["gates"] = await self.hass.async_add_executor_job(
                         bridge.get_programmable_gates, service_id, service_type
                     )
 
                     # Update thermo devices data from Jablotron Cloud
                     _LOGGER.debug("Updating thermo devices data for service '%d'", service_id)
-                    self._client.services[service_id]["thermo"] = await self.hass.async_add_executor_job(
+                    service_data["thermo"] = await self.hass.async_add_executor_job(
                         bridge.get_thermo_devices, service_id, service_type
                     )
 

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -123,26 +123,22 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         """Whether code is required for arm actions."""
         return self._authorization_required
 
-    async def async_alarm_disarm(self, code: str | None = None) -> None:
-        """Send disarm request."""
+    async def _async_control_section(self, state: str, code: str | None, force: bool = False) -> bool:
+        """Send a control request for this section and return whether it succeeded."""
         try:
-            code = self.code_or_default_code(code)
-            _LOGGER.debug("Sending disarm for section '%s' (service %d)", self._section_name, self._service_id)
             async with timeout(self.coordinator.scan_timeout):
                 bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-                disarm_successful = await self.hass.async_add_executor_job(
+                return await self.hass.async_add_executor_job(
                     partial(
                         bridge.control_section,
                         service_id=self._service_id,
                         service_type=self._service_type,
                         component_id=self._section_id,
-                        state="DISARM",
+                        state=state,
                         pin_code=code,
+                        force=force,
                     )
                 )
-            if disarm_successful:
-                self._attr_alarm_state = AlarmControlPanelState.DISARMING
-                self.async_write_ha_state()
         except TimeoutError as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
         except UnauthorizedException as ex:
@@ -150,74 +146,42 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         except IncorrectPinCodeException as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
 
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm request."""
+        code = self.code_or_default_code(code)
+        _LOGGER.debug("Sending disarm for section '%s' (service %d)", self._section_name, self._service_id)
+        if await self._async_control_section("DISARM", code):
+            self._attr_alarm_state = AlarmControlPanelState.DISARMING
+            self.async_write_ha_state()
+
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm request."""
-        try:
-            code = self.code_or_default_code(code)
-            _LOGGER.debug(
-                "Sending arm away for section '%s' (service %d, force=%s)",
-                self._section_name,
-                self._service_id,
-                self._client.force_arm,
-            )
-            async with timeout(self.coordinator.scan_timeout):
-                bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-                arm_successful = await self.hass.async_add_executor_job(
-                    partial(
-                        bridge.control_section,
-                        service_id=self._service_id,
-                        service_type=self._service_type,
-                        component_id=self._section_id,
-                        state="ARM",
-                        pin_code=code,
-                        force=self._client.force_arm,
-                    )
-                )
-            if arm_successful:
-                self._attr_alarm_state = AlarmControlPanelState.ARMING
-                self.async_write_ha_state()
-        except TimeoutError as ex:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
-        except UnauthorizedException as ex:
-            raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException as ex:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
+        code = self.code_or_default_code(code)
+        _LOGGER.debug(
+            "Sending arm away for section '%s' (service %d, force=%s)",
+            self._section_name,
+            self._service_id,
+            self._client.force_arm,
+        )
+        if await self._async_control_section("ARM", code, force=self._client.force_arm):
+            self._attr_alarm_state = AlarmControlPanelState.ARMING
+            self.async_write_ha_state()
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send partial arm request."""
         if not self._supports_partial_arm:
             return
 
-        try:
-            code = self.code_or_default_code(code)
-            _LOGGER.debug(
-                "Sending arm home for section '%s' (service %d, force=%s)",
-                self._section_name,
-                self._service_id,
-                self._client.force_arm,
-            )
-            async with timeout(self.coordinator.scan_timeout):
-                bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-                arm_successful = await self.hass.async_add_executor_job(
-                    partial(
-                        bridge.control_section,
-                        service_id=self._service_id,
-                        service_type=self._service_type,
-                        component_id=self._section_id,
-                        state="PARTIAL_ARM",
-                        pin_code=code,
-                        force=self._client.force_arm,
-                    )
-                )
-            if arm_successful:
-                self._attr_alarm_state = AlarmControlPanelState.ARMING
-                self.async_write_ha_state()
-        except TimeoutError as ex:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
-        except UnauthorizedException as ex:
-            raise ConfigEntryAuthFailed(ex) from ex
-        except IncorrectPinCodeException as ex:
-            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="invalid_pin") from ex
+        code = self.code_or_default_code(code)
+        _LOGGER.debug(
+            "Sending arm home for section '%s' (service %d, force=%s)",
+            self._section_name,
+            self._service_id,
+            self._client.force_arm,
+        )
+        if await self._async_control_section("PARTIAL_ARM", code, force=self._client.force_arm):
+            self._attr_alarm_state = AlarmControlPanelState.ARMING
+            self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from asyncio import timeout
 from functools import partial
 import logging
 
@@ -127,20 +128,23 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         try:
             code = self.code_or_default_code(code)
             _LOGGER.debug("Sending disarm for section '%s' (service %d)", self._section_name, self._service_id)
-            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-            disarm_successful = await self.hass.async_add_executor_job(
-                partial(
-                    bridge.control_section,
-                    service_id=self._service_id,
-                    service_type=self._service_type,
-                    component_id=self._section_id,
-                    state="DISARM",
-                    pin_code=code,
+            async with timeout(self.coordinator.scan_timeout):
+                bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+                disarm_successful = await self.hass.async_add_executor_job(
+                    partial(
+                        bridge.control_section,
+                        service_id=self._service_id,
+                        service_type=self._service_type,
+                        component_id=self._section_id,
+                        state="DISARM",
+                        pin_code=code,
+                    )
                 )
-            )
             if disarm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.DISARMING
                 self.async_write_ha_state()
+        except TimeoutError as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
@@ -156,21 +160,24 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                 self._service_id,
                 self._client.force_arm,
             )
-            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-            arm_successful = await self.hass.async_add_executor_job(
-                partial(
-                    bridge.control_section,
-                    service_id=self._service_id,
-                    service_type=self._service_type,
-                    component_id=self._section_id,
-                    state="ARM",
-                    pin_code=code,
-                    force=self._client.force_arm,
+            async with timeout(self.coordinator.scan_timeout):
+                bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+                arm_successful = await self.hass.async_add_executor_job(
+                    partial(
+                        bridge.control_section,
+                        service_id=self._service_id,
+                        service_type=self._service_type,
+                        component_id=self._section_id,
+                        state="ARM",
+                        pin_code=code,
+                        force=self._client.force_arm,
+                    )
                 )
-            )
             if arm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
                 self.async_write_ha_state()
+        except TimeoutError as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
@@ -189,21 +196,24 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                 self._service_id,
                 self._client.force_arm,
             )
-            bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
-            arm_successful = await self.hass.async_add_executor_job(
-                partial(
-                    bridge.control_section,
-                    service_id=self._service_id,
-                    service_type=self._service_type,
-                    component_id=self._section_id,
-                    state="PARTIAL_ARM",
-                    pin_code=code,
-                    force=self._client.force_arm,
+            async with timeout(self.coordinator.scan_timeout):
+                bridge = await self.hass.async_add_executor_job(self._client.get_bridge)
+                arm_successful = await self.hass.async_add_executor_job(
+                    partial(
+                        bridge.control_section,
+                        service_id=self._service_id,
+                        service_type=self._service_type,
+                        component_id=self._section_id,
+                        state="PARTIAL_ARM",
+                        pin_code=code,
+                        force=self._client.force_arm,
+                    )
                 )
-            )
             if arm_successful:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
                 self.async_write_ha_state()
+        except TimeoutError as ex:
+            raise HomeAssistantError(translation_domain=DOMAIN, translation_key="action_timeout") from ex
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:

--- a/custom_components/jablotron_cloud/config_flow.py
+++ b/custom_components/jablotron_cloud/config_flow.py
@@ -15,21 +15,25 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_USERNAME,
 )
+from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 
 from .const import DOMAIN
 from .jablotron import JablotronClient
 
 _LOGGER = logging.getLogger(__name__)
 
+PASSWORD_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+
 
 def get_schema(config: dict) -> vol.Schema:
     """Return config flow schema."""
 
+    # Never pre-fill the stored PIN so it cannot be read back from the form.
     return vol.Schema(
         {
             vol.Required(CONF_USERNAME, default=config.get(CONF_USERNAME, "")): str,
-            vol.Required(CONF_PASSWORD): str,
-            vol.Optional(CONF_PIN, default=config.get(CONF_PIN, "")): str,
+            vol.Required(CONF_PASSWORD): PASSWORD_SELECTOR,
+            vol.Optional(CONF_PIN, default=""): PASSWORD_SELECTOR,
             vol.Optional(CONF_FORCE_UPDATE, default=config.get(CONF_FORCE_UPDATE, True)): bool,
             vol.Optional(CONF_SCAN_INTERVAL, default=config.get(CONF_SCAN_INTERVAL, 30)): int,
             vol.Optional(CONF_TIMEOUT, default=config.get(CONF_TIMEOUT, 15)): int,
@@ -76,6 +80,14 @@ async def handle_configuration(
         )
 
 
+def keep_stored_pin_if_empty(user_input: dict) -> dict:
+    """Return user input without an empty PIN so the stored PIN is kept on update."""
+
+    if not user_input.get(CONF_PIN):
+        return {key: value for key, value in user_input.items() if key != CONF_PIN}
+    return user_input
+
+
 def validate_credentials(user_input: dict) -> None:
     """Validate that user entered valid credentials."""
 
@@ -118,7 +130,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(  # type: ignore[return-value]
                 config_entry,
                 unique_id=config_entry.unique_id,
-                data={**config_entry.data, **user_input},
+                data={**config_entry.data, **keep_stored_pin_if_empty(user_input)},
             )
         return flow_result  # type: ignore[return-value]
 
@@ -142,6 +154,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(  # type: ignore[return-value]
                 config_entry,
                 unique_id=config_entry.unique_id,
-                data={**config_entry.data, **user_input},
+                data={**config_entry.data, **keep_stored_pin_if_empty(user_input)},
             )
         return flow_result  # type: ignore[return-value]

--- a/custom_components/jablotron_cloud/jablotron.py
+++ b/custom_components/jablotron_cloud/jablotron.py
@@ -8,8 +8,6 @@ from .types import JablotronServiceData
 class JablotronClient:
     """Client for Jablotron Cloud API."""
 
-    services: dict[int, JablotronServiceData] = {}
-
     def __init__(
         self,
         username: str,
@@ -23,6 +21,8 @@ class JablotronClient:
         self._password = password
         self._default_pin = default_pin
         self.force_arm = force_arm
+        # Service data must be per-instance so multiple config entries never share or mix account data.
+        self.services: dict[int, JablotronServiceData] = {}
 
     def get_bridge(self) -> Jablotron:
         """Return Jablotron bridge instance."""

--- a/custom_components/jablotron_cloud/strings.json
+++ b/custom_components/jablotron_cloud/strings.json
@@ -19,6 +19,9 @@
                     "force_update": "[%key:common::config_flow::data::force_update%]",
                     "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
                     "timeout": "[%key:common::config_flow::data::timeout%]"
+                },
+                "data_description": {
+                    "pin": "Leave empty to keep the currently stored PIN."
                 }
             },
             "reauth_confirm": {
@@ -29,6 +32,9 @@
                     "force_update": "[%key:common::config_flow::data::force_update%]",
                     "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
                     "timeout": "[%key:common::config_flow::data::timeout%]"
+                },
+                "data_description": {
+                    "pin": "Leave empty to keep the currently stored PIN."
                 }
             }
         },
@@ -44,6 +50,9 @@
         }
     },
     "exceptions": {
+        "action_timeout": {
+            "message": "Timed out while sending the command to Jablotron Cloud!"
+        },
         "invalid_pin": {
             "message": "Provided pin code is not valid!"
         },

--- a/custom_components/jablotron_cloud/translations/cs.json
+++ b/custom_components/jablotron_cloud/translations/cs.json
@@ -19,6 +19,9 @@
                     "force_update": "Bypassovat chyby sekcí",
                     "scan_interval": "Interval aktualizací (v sekundách)",
                     "timeout": "Časový limit aktualizace (v sekundách)"
+                },
+                "data_description": {
+                    "pin": "Ponechte prázdné pro zachování aktuálně uloženého PINu."
                 }
             },
             "reauth_confirm": {
@@ -29,6 +32,9 @@
                     "force_update": "Bypassovat chyby sekcí",
                     "scan_interval": "Interval aktualizací (v sekundách)",
                     "timeout": "Časový limit aktualizace (v sekundách)"
+                },
+                "data_description": {
+                    "pin": "Ponechte prázdné pro zachování aktuálně uloženého PINu."
                 }
             }
         },
@@ -44,6 +50,9 @@
         }
     },
     "exceptions": {
+        "action_timeout": {
+            "message": "Vypršel časový limit při odesílání příkazu do Jablotron Cloud!"
+        },
         "invalid_pin": {
             "message": "Zadaný PIN kód není platný!"
         },

--- a/custom_components/jablotron_cloud/translations/en.json
+++ b/custom_components/jablotron_cloud/translations/en.json
@@ -19,6 +19,9 @@
                     "force_update": "Bypass section errors",
                     "scan_interval": "Update interval (seconds)",
                     "timeout": "Update timeout (seconds)"
+                },
+                "data_description": {
+                    "pin": "Leave empty to keep the currently stored PIN."
                 }
             },
             "reauth_confirm": {
@@ -29,6 +32,9 @@
                     "force_update": "Bypass section errors",
                     "scan_interval": "Update interval (seconds)",
                     "timeout": "Update timeout (seconds)"
+                },
+                "data_description": {
+                    "pin": "Leave empty to keep the currently stored PIN."
                 }
             }
         },
@@ -44,6 +50,9 @@
         }
     },
     "exceptions": {
+        "action_timeout": {
+            "message": "Timed out while sending the command to Jablotron Cloud!"
+        },
         "invalid_pin": {
             "message": "The entered pin code is not valid!"
         },

--- a/custom_components/jablotron_cloud/translations/nl.json
+++ b/custom_components/jablotron_cloud/translations/nl.json
@@ -19,6 +19,9 @@
                     "force_update": "Bypass section errors",
                     "scan_interval": "Update-interval (seconden)",
                     "timeout": "Update-time-out (seconden)"
+                },
+                "data_description": {
+                    "pin": "Laat leeg om de momenteel opgeslagen pincode te behouden."
                 }
             },
             "reauth_confirm": {
@@ -29,6 +32,9 @@
                     "force_update": "Bypass section errors",
                     "scan_interval": "Update-interval (seconden)",
                     "timeout": "Update-time-out (seconden)"
+                },
+                "data_description": {
+                    "pin": "Laat leeg om de momenteel opgeslagen pincode te behouden."
                 }
             }
         },
@@ -44,6 +50,9 @@
         }
     },
     "exceptions": {
+        "action_timeout": {
+            "message": "Time-out bij het verzenden van de opdracht naar Jablotron Cloud!"
+        },
         "invalid_pin": {
             "message": "De ingevoerde pincode is niet geldig!"
         },

--- a/custom_components/jablotron_cloud/translations/sk.json
+++ b/custom_components/jablotron_cloud/translations/sk.json
@@ -19,6 +19,9 @@
                     "force_update": "Bypassovať chyby sekcií",
                     "scan_interval": "Interval aktualizácií (v sekundách)",
                     "timeout": "Časový limit aktualizácie (v sekundách)"
+                },
+                "data_description": {
+                    "pin": "Ponechajte prázdne pre zachovanie aktuálne uloženého PINu."
                 }
             },
             "reauth_confirm": {
@@ -29,6 +32,9 @@
                     "force_update": "Bypassovať chyby sekcií",
                     "scan_interval": "Interval aktualizácií (v sekundách)",
                     "timeout": "Časový limit aktualizácie (v sekundách)"
+                },
+                "data_description": {
+                    "pin": "Ponechajte prázdne pre zachovanie aktuálne uloženého PINu."
                 }
             }
         },
@@ -44,6 +50,9 @@
         }
     },
     "exceptions": {
+        "action_timeout": {
+            "message": "Vypršal časový limit pri odosielaní príkazu do Jablotron Cloud!"
+        },
         "invalid_pin": {
             "message": "Zadaný PIN kód nie je platný!"
         },


### PR DESCRIPTION
- Make JablotronClient.services an instance attribute instead of a shared
  class attribute so multiple config entries cannot mix account data, and
  clear it on unload so reloads start clean
- Mask password and PIN fields in the config flow and stop pre-filling the
  stored PIN into the reconfigure/reauth form; an empty PIN now keeps the
  stored value (documented via data_description in all translations)
- Wrap alarm arm/disarm actions in the configured update timeout so a hung
  cloud request fails with a translated error instead of hanging forever

https://claude.ai/code/session_011TzVDZtyVGWCxYp2EFzaia