### PR TITLE
Fix section bypass (BYPASS-TIMED) and report bypasses to Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ecosystem:
 | Entity type           | Description                                                     |
 |-----------------------|-----------------------------------------------------------------|
 | `alarm_control_panel` | Used for monitoring and controlling alarm sections (including `triggered` state when an alarm is active) |
-| `binary_sensor`       | Used for monitoring **UN**controllable programmable gates (PGs) |
+| `binary_sensor`       | Used for monitoring **UN**controllable programmable gates (PGs), and for reporting section bypasses |
 | `climate`             | Used for controlling thermo devices (thermostats)               |
 | `switch`              | Used for controlling programmable gates (PGs)                   |
 | `sensor`              | Used for monitoring temperature sensors and non-controllable section states |
@@ -75,10 +75,85 @@ The integration allows you to modify the following parameters:
 * Frequency of polling data from Jablotron Cloud
 * Timeout for polling data from Jablotron Cloud
 
+## Section bypass (arming with an open door or window)
+
+Arming a section whose detectors are not all closed requires a bypass - the confirmation the
+MyJablotron app shows before it lets you arm anyway. This integration reproduces that flow in two
+steps:
+
+1. The section is armed normally. When every detector is closed nothing else happens, so a clean
+   arm still costs a single request.
+2. When the cloud answers with a `BYPASS-TIMED` (or `BYPASS`) control error, active devices are
+   blocking the section. If *Bypass section errors* is enabled the request is repeated with the
+   bypass confirmed and the bypass is reported to Home Assistant. If it is disabled the arm fails
+   with the cloud error, exactly as before.
+
+> **Note on the payload.** The `force` flag is only honoured by the cloud when it sits inside the
+> request's `actions` object. [JablotronPy](https://github.com/fdegier/JablotronPy) 0.7.4 places it
+> next to `component-id`, where it is silently ignored, so arming a section with an open window
+> always failed with `BYPASS-TIMED` regardless of configuration. This integration therefore builds
+> the section control payload itself instead of calling `control_section()`.
+
+### Bypass entities and events
+
+Every controllable section gets a `binary_sensor` bypass indicator. It turns `on` for 30 seconds
+after an arm that required a bypass and then clears itself, which makes it convenient for firing a
+notification or a dashboard pop-up. The attributes describe the most recent bypass and remain
+readable after the sensor clears:
+
+| Attribute       | Description                                              |
+|-----------------|----------------------------------------------------------|
+| `section_name`  | Name of the section that was armed                        |
+| `section_id`    | Cloud component id of the section, e.g. `SEC-8902238`     |
+| `control_error` | Code reported by the cloud, e.g. `BYPASS-TIMED`           |
+| `bypassed_at`   | ISO 8601 timestamp of the bypass                          |
+
+The same payload is fired on the event bus as `jablotron_cloud_section_bypassed`, carrying
+`service_id`, `service_name`, `section_id`, `section_name` and `control_error`.
+
+```yaml
+- alias: Jablotron armed with a bypass
+  trigger:
+    - platform: event
+      event_type: jablotron_cloud_section_bypassed
+  action:
+    - service: notify.mobile_app
+      data:
+        title: "Armed with bypass"
+        message: >-
+          Section {{ trigger.event.data.section_name }} was armed while devices were active.
+```
+
+### Which device caused the bypass?
+
+**The cloud does not say, and it cannot be derived from the API.** The bypass error identifies the
+section only. There is no endpoint that lists detectors: `peripheralsGet`, `devicesGet` and
+`deviceStatesGet` all answer `FUNCTION.NOT-FOUND`, and `eventHistoryGet` answers
+`METHOD.NOT-SUPPORTED` on several panels. The mobile API exposes sections, PGs, thermo devices and
+keyboard segments and nothing below them.
+
+If you want to name the door or window, correlate the section with your own contact sensors:
+
+```yaml
+- alias: Show which window forced the bypass
+  trigger:
+    - platform: event
+      event_type: jablotron_cloud_section_bypassed
+  action:
+    - service: notify.mobile_app
+      data:
+        title: "Armed with bypass"
+        message: >-
+          {% set open = states.binary_sensor
+               | selectattr('attributes.device_class', 'in', ['window', 'door'])
+               | selectattr('state', 'eq', 'on') | map(attribute='name') | list %}
+          {{ trigger.event.data.section_name }} armed. Open: {{ open | join(', ') or 'unknown' }}
+```
+
 ## Alarm event detection
 
 The integration surfaces an active alarm by flipping the affected `alarm_control_panel` entity to the
-`triggered` state. Detection is **per section** — when an alarm is in progress, the Jablotron Cloud API
+`triggered` state. Detection is **per section** - when an alarm is in progress, the Jablotron Cloud API
 returns an event with a message such as `"Alarm - Periphery PIR chodba (wifi), Section Dům"`. The
 integration parses the section name from the substring after the `, Section ` token and only the matching
 section is reported as `triggered`. Other sections of the same service stay in their previous state.
@@ -119,5 +194,3 @@ Example automation that fires whenever any alarm panel is triggered:
   with a redacted log sample if you observe this.
 * **Historical events are not used.** The cloud-side event history endpoint (`eventHistoryGet`) returns
   `400 METHOD.NOT-SUPPORTED` on several panel models (e.g. JA100F), so it is not relied on as a fallback.
-
-

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ If you want to name the door or window, correlate the section with your own cont
 ## Alarm event detection
 
 The integration surfaces an active alarm by flipping the affected `alarm_control_panel` entity to the
-`triggered` state. Detection is **per section** - when an alarm is in progress, the Jablotron Cloud API
+`triggered` state. Detection is **per section** — when an alarm is in progress, the Jablotron Cloud API
 returns an event with a message such as `"Alarm - Periphery PIR chodba (wifi), Section Dům"`. The
 integration parses the section name from the substring after the `, Section ` token and only the matching
 section is reported as `triggered`. Other sections of the same service stay in their previous state.
@@ -194,3 +194,5 @@ Example automation that fires whenever any alarm panel is triggered:
   with a redacted log sample if you observe this.
 * **Historical events are not used.** The cloud-side event history endpoint (`eventHistoryGet`) returns
   `400 METHOD.NOT-SUPPORTED` on several panel models (e.g. JA100F), so it is not relied on as a fallback.
+
+

--- a/custom_components/jablotron_cloud/alarm_control_panel.py
+++ b/custom_components/jablotron_cloud/alarm_control_panel.py
@@ -15,10 +15,11 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
-from .const import DOMAIN
+from .const import DOMAIN, EVENT_SECTION_BYPASSED, SIGNAL_SECTION_BYPASSED
 from .entity import JablotronEntity
 from .utils import find_section_alarm_event, get_component_state, section_state_to_alarm_state
 
@@ -127,7 +128,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
         try:
             code = self.code_or_default_code(code)
             _LOGGER.debug("Sending disarm for section '%s' (service %d)", self._section_name, self._service_id)
-            disarm_successful = await self.hass.async_add_executor_job(
+            disarm_result = await self.hass.async_add_executor_job(
                 partial(
                     self._client.control_section,
                     service_id=self._service_id,
@@ -137,7 +138,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                     pin_code=code,
                 )
             )
-            if disarm_successful:
+            if disarm_result.success:
                 self._attr_alarm_state = AlarmControlPanelState.DISARMING
                 self.async_write_ha_state()
         except UnauthorizedException as ex:
@@ -159,7 +160,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                 self._service_id,
                 self._client.force_arm,
             )
-            arm_successful = await self.hass.async_add_executor_job(
+            arm_result = await self.hass.async_add_executor_job(
                 partial(
                     self._client.control_section,
                     service_id=self._service_id,
@@ -170,9 +171,11 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                     force=self._client.force_arm,
                 )
             )
-            if arm_successful:
+            if arm_result.success:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
                 self.async_write_ha_state()
+            if arm_result.bypassed:
+                self._report_bypass(arm_result.control_error)
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
@@ -195,7 +198,7 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                 self._service_id,
                 self._client.force_arm,
             )
-            arm_successful = await self.hass.async_add_executor_job(
+            arm_result = await self.hass.async_add_executor_job(
                 partial(
                     self._client.control_section,
                     service_id=self._service_id,
@@ -206,9 +209,11 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
                     force=self._client.force_arm,
                 )
             )
-            if arm_successful:
+            if arm_result.success:
                 self._attr_alarm_state = AlarmControlPanelState.ARMING
                 self.async_write_ha_state()
+            if arm_result.bypassed:
+                self._report_bypass(arm_result.control_error)
         except UnauthorizedException as ex:
             raise ConfigEntryAuthFailed(ex) from ex
         except IncorrectPinCodeException as ex:
@@ -217,6 +222,33 @@ class JablotronAlarmControlPanel(JablotronEntity, AlarmControlPanelEntity):
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="rate_limited") from ex
         except Exception as ex:
             raise HomeAssistantError(translation_domain=DOMAIN, translation_key="alarm_control_failed") from ex
+
+    @callback
+    def _report_bypass(self, control_error: str | None) -> None:
+        """Announce that this section could only be armed by bypassing active devices.
+
+        The cloud names nothing but the section in its bypass error, so this is as specific as
+        the report can get. Consumers wanting to show which door or window was open have to
+        correlate the section with their own contact sensors.
+        """
+
+        _LOGGER.info(
+            "Section '%s' was armed with active devices bypassed (%s)",
+            self._section_name,
+            control_error,
+        )
+        payload = {
+            "service_id": self._service_id,
+            "service_name": self._service_name,
+            "section_id": self._section_id,
+            "section_name": self._section_name,
+            "control_error": control_error,
+        }
+
+        # The bus event drives user automations, the dispatcher signal drives this section's
+        # bypass binary sensor.
+        self.hass.bus.async_fire(EVENT_SECTION_BYPASSED, payload)
+        async_dispatcher_send(self.hass, SIGNAL_SECTION_BYPASSED, payload)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/jablotron_cloud/binary_sensor.py
+++ b/custom_components/jablotron_cloud/binary_sensor.py
@@ -1,16 +1,22 @@
-"""Support for Jablotron PG binary sensors."""
+"""Support for Jablotron PG binary sensors and section bypass indicators."""
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
+from typing import Any
 
 from jablotronpy import JablotronProgrammableGatesGate
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+from homeassistant.util import dt as dt_util
 
 from . import JablotronClient, JablotronConfigEntry, JablotronData, JablotronDataCoordinator
+from .const import BYPASS_SIGNAL_DURATION, SIGNAL_SECTION_BYPASSED
 from .entity import JablotronEntity
 from .utils import get_component_state, pg_state_to_binary_state
 
@@ -22,18 +28,40 @@ async def async_setup_entry(
     entry: JablotronConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Register binary sensor entity for each Jablotron service uncontrollable programmable gate."""
+    """Register a bypass indicator per section and a binary sensor per uncontrollable PG."""
 
     _LOGGER.debug("Adding Jablotron binary sensor entities")
     runtime_data: JablotronData = entry.runtime_data
     coordinator = runtime_data.coordinator
     client = runtime_data.client
 
-    entities: list[JablotronProgrammableGate] = []
+    entities: list[BinarySensorEntity] = []
     for service_id, service_data in client.services.items():
         service_name = service_data["name"]
         service_type = service_data["type"]
         service_firmware = service_data["firmware"]
+
+        # One bypass indicator per controllable section. A bypass is only ever reported while
+        # answering a control request, so these entities are driven by those replies instead of
+        # by the coordinator.
+        _LOGGER.debug("Getting available sections for service '%s'", service_name)
+        for section in service_data["alarm"].get("sections", []):
+            if not section["can-control"]:
+                continue
+
+            _LOGGER.debug("Adding bypass indicator for section '%s'", section["name"])
+            entities.append(
+                JablotronSectionBypass(
+                    coordinator,
+                    client,
+                    service_id,
+                    service_name,
+                    service_type,
+                    service_firmware,
+                    section["cloud-component-id"],
+                    section["name"],
+                )
+            )
 
         _LOGGER.debug("Getting available programmable gates for service '%s'", service_name)
         gates = service_data["gates"]
@@ -64,6 +92,81 @@ async def async_setup_entry(
             )
 
     async_add_entities(entities)
+
+
+class JablotronSectionBypass(JablotronEntity, BinarySensorEntity):
+    """Short lived indicator that a section was armed with active devices bypassed.
+
+    The cloud never volunteers this; it only surfaces while a control request is answered, so
+    the entity pulses for ``BYPASS_SIGNAL_DURATION`` and is meant to trigger a notification or
+    a dashboard pop-up. Its attributes keep the details of the last bypass after it clears.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_icon = "mdi:shield-alert-outline"
+
+    def __init__(
+        self,
+        coordinator: JablotronDataCoordinator,
+        client: JablotronClient,
+        service_id: int,
+        service_name: str,
+        service_type: str,
+        service_firmware: str,
+        section_id: str,
+        section_name: str,
+    ) -> None:
+        """Initialize Jablotron section bypass indicator."""
+        self._section_id = section_id
+        self._section_name = section_name
+        self._attr_name = f"{section_name} bypass"
+        self._attr_unique_id = f"{service_id}_{section_id}_bypass"
+        self._attr_is_on = False
+        self._attr_extra_state_attributes: dict[str, Any] = {}
+        self._cancel_auto_off: CALLBACK_TYPE | None = None
+        super().__init__(coordinator, client, service_id, service_name, service_type, service_firmware)
+
+    async def async_added_to_hass(self) -> None:
+        """Start listening for bypasses reported by the alarm panel entities."""
+        await super().async_added_to_hass()
+        self.async_on_remove(async_dispatcher_connect(self.hass, SIGNAL_SECTION_BYPASSED, self._handle_bypass))
+        self.async_on_remove(self._cancel_pending_auto_off)
+
+    @callback
+    def _handle_bypass(self, payload: dict[str, Any]) -> None:
+        """Pulse when the bypass belongs to this section."""
+        if payload["service_id"] != self._service_id or payload["section_id"] != self._section_id:
+            return
+
+        # Restart the full duration when bypasses overlap, so the pulse never ends early.
+        self._cancel_pending_auto_off()
+        self._attr_is_on = True
+        self._attr_extra_state_attributes = {
+            "section_name": payload["section_name"],
+            "section_id": payload["section_id"],
+            "control_error": payload["control_error"],
+            "bypassed_at": dt_util.now().isoformat(),
+        }
+        self.async_write_ha_state()
+        self._cancel_auto_off = async_call_later(self.hass, BYPASS_SIGNAL_DURATION, self._clear_bypass)
+
+    @callback
+    def _clear_bypass(self, _now: datetime) -> None:
+        """Clear the indicator once the signal duration elapsed, keeping the attributes."""
+        self._cancel_auto_off = None
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @callback
+    def _cancel_pending_auto_off(self) -> None:
+        """Drop a scheduled clear, if one is still pending."""
+        if self._cancel_auto_off is not None:
+            self._cancel_auto_off()
+            self._cancel_auto_off = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Ignore polled data: this entity is driven purely by control responses."""
 
 
 class JablotronProgrammableGate(JablotronEntity, BinarySensorEntity):

--- a/custom_components/jablotron_cloud/const.py
+++ b/custom_components/jablotron_cloud/const.py
@@ -1,5 +1,7 @@
 """Constants for Jablotron Cloud integration."""
 
+from datetime import timedelta
+
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.components.climate import HVACMode
 from homeassistant.const import Platform
@@ -15,6 +17,23 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
+
+# Section bypass constants
+# Control errors meaning "devices in this section are active and must be bypassed to arm".
+# The cloud reports them against the section only; the API exposes no endpoint listing
+# detectors, so a bypass can never be attributed to the door or window that caused it.
+BYPASS_CONTROL_ERRORS = ("BYPASS", "BYPASS-TIMED")
+
+# How long a section's bypass binary sensor stays on after an arm that required a bypass.
+# A bypass is only ever reported in the reply to a control request, so the sensor is a short
+# pulse meant to drive a notification or a pop-up rather than a lasting state.
+BYPASS_SIGNAL_DURATION = timedelta(seconds=30)
+
+# Fired on the Home Assistant bus for every arm that required active devices to be bypassed.
+EVENT_SECTION_BYPASSED = f"{DOMAIN}_section_bypassed"
+
+# Dispatcher signal telling a section's bypass binary sensor to pulse.
+SIGNAL_SECTION_BYPASSED = f"{DOMAIN}_section_bypassed_signal"
 
 # Jablotron states as Home Assistant states
 SECTION_STATE_AS_ALARM_STATE = {

--- a/custom_components/jablotron_cloud/jablotron.py
+++ b/custom_components/jablotron_cloud/jablotron.py
@@ -152,13 +152,20 @@ class JablotronClient:
 
         return self._api_call(
             lambda bridge: self._control_section(
-                bridge, service_id, component_id, state, pin_code, service_type, force
+                bridge,
+                service_id=service_id,
+                component_id=component_id,
+                state=state,
+                pin_code=pin_code,
+                service_type=service_type,
+                force=force,
             )
         )
 
     @staticmethod
     def _control_section(
         bridge: Jablotron,
+        *,
         service_id: int,
         component_id: str,
         state: Literal["ARM", "PARTIAL_ARM", "DISARM"],

--- a/custom_components/jablotron_cloud/jablotron.py
+++ b/custom_components/jablotron_cloud/jablotron.py
@@ -8,6 +8,7 @@ from typing import Literal
 from jablotronpy import (
     Jablotron,
     JablotronProgrammableGates,
+    JablotronSectionControlResponse,
     JablotronSections,
     JablotronService,
     JablotronServiceInformation,
@@ -16,9 +17,20 @@ from jablotronpy import (
     UnauthorizedException,
 )
 
-from .types import JablotronServiceData
+from .const import BYPASS_CONTROL_ERRORS
+from .types import JablotronSectionControlResult, JablotronServiceData
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _find_bypass_error(response_data: JablotronSectionControlResponse, component_id: str) -> str | None:
+    """Return the bypass control error reported for a component, when the cloud reported one."""
+
+    for error in response_data.get("control-errors") or []:
+        if error["component-id"] == component_id and error["control-error"] in BYPASS_CONTROL_ERRORS:
+            return error["control-error"]
+
+    return None
 
 
 class JablotronClient:
@@ -128,12 +140,86 @@ class JablotronClient:
         pin_code: str | None = None,
         service_type: str = "JA100",
         force: bool = False,
-    ) -> bool:
-        """Set section of the specified service to the desired state."""
+    ) -> JablotronSectionControlResult:
+        """Set section of the specified service to the desired state.
+
+        Follows the same two steps as the official MyJablotron app: the state is requested
+        normally first, and only when the cloud answers that active devices block the section
+        is the request repeated with the bypass confirmed. Sections whose devices are all
+        closed therefore still cost a single request, and a bypass becomes an observable event
+        instead of something that silently happens on every arm.
+        """
 
         return self._api_call(
-            lambda bridge: bridge.control_section(service_id, component_id, state, pin_code, service_type, force)
+            lambda bridge: self._control_section(
+                bridge, service_id, component_id, state, pin_code, service_type, force
+            )
         )
+
+    @staticmethod
+    def _control_section(
+        bridge: Jablotron,
+        service_id: int,
+        component_id: str,
+        state: Literal["ARM", "PARTIAL_ARM", "DISARM"],
+        pin_code: str | None,
+        service_type: str,
+        force: bool,
+    ) -> JablotronSectionControlResult:
+        """Request a section state, confirming a bypass only when the cloud asks for one."""
+
+        # The payload is built here instead of calling ``bridge.control_section()`` because
+        # jablotronpy 0.7.4 places the ``force`` flag next to ``component-id``, where the cloud
+        # silently ignores it: arming a section that has an open window then always answers
+        # ``BYPASS-TIMED`` and nothing is armed, however the integration is configured. The flag
+        # is only honoured inside the ``actions`` object. Verified against a JA-106K panel on
+        # 2026-08-08; see https://github.com/fdegier/JablotronPy for the upstream bug.
+        pin_code = bridge._get_provided_pin_or_default_pin(pin_code)  # noqa: SLF001
+
+        def request(with_bypass: bool) -> JablotronSectionControlResponse:
+            """Send one control request, bypassing active devices when asked to."""
+
+            response = bridge._send_request(  # noqa: SLF001
+                endpoint=f"{service_type}/controlComponent.json",
+                payload={
+                    "service-id": service_id,
+                    "authorization": {"authorization-code": pin_code},
+                    "control-components": [
+                        {
+                            "actions": {
+                                "action": "CONTROL-SECTION",
+                                "value": state.upper(),
+                                "force": with_bypass,
+                            },
+                            "component-id": component_id,
+                        }
+                    ],
+                },
+            )
+
+            return response.json().get("data", {})
+
+        response_data = request(with_bypass=False)
+        bypass_error = _find_bypass_error(response_data, component_id)
+
+        # Either nothing had to be bypassed or bypassing is switched off in the configuration.
+        # Letting jablotronpy judge the response keeps WRONG-CODE and every other control error
+        # raising exactly the same exceptions as upstream.
+        if bypass_error is None or not force:
+            success = bridge._was_control_action_successful(response_data, component_id, state)  # noqa: SLF001
+            return JablotronSectionControlResult(success=success)
+
+        # Active devices block the section and bypassing is allowed, so confirm it the way the
+        # app does once the user acknowledges its bypass prompt.
+        _LOGGER.debug(
+            "Section '%s' answered '%s', repeating the request with the bypass confirmed",
+            component_id,
+            bypass_error,
+        )
+        response_data = request(with_bypass=True)
+        success = bridge._was_control_action_successful(response_data, component_id, state)  # noqa: SLF001
+
+        return JablotronSectionControlResult(success=success, bypassed=success, control_error=bypass_error)
 
     def control_programmable_gate(
         self,

--- a/custom_components/jablotron_cloud/manifest.json
+++ b/custom_components/jablotron_cloud/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "jablotronpy==0.7.4"
     ],
-    "version": "0.9.0"
+    "version": "0.10.0"
 }

--- a/custom_components/jablotron_cloud/types.py
+++ b/custom_components/jablotron_cloud/types.py
@@ -15,6 +15,22 @@ class JablotronServiceCapabilities:
     has_thermo: bool
 
 
+@dataclass(frozen=True)
+class JablotronSectionControlResult:
+    """Outcome of a single section control request.
+
+    ``bypassed`` is True when the section could only reach the requested state because active
+    devices were bypassed; ``control_error`` then carries the code the cloud reported for the
+    first, un-forced attempt (``BYPASS-TIMED`` for example). The cloud identifies only the
+    section in that error, never the detector that triggered it, so nothing more specific than
+    the section can be reported to Home Assistant.
+    """
+
+    success: bool
+    bypassed: bool = False
+    control_error: str | None = None
+
+
 class JablotronServiceData(TypedDict):
     """Typed dictionary representing data for a single Jablotron service."""
 


### PR DESCRIPTION
Fixes #67.

## Problem

Arming a section that has an open door or window always fails with `Failed to control alarm section!`, no matter how *Bypass section errors* is configured. The underlying cloud error is `BYPASS-TIMED`, and it is swallowed by the generic `ControlActionException` -> `alarm_control_failed` mapping, so the log never shows the real reason.

## Root cause

`jablotronpy` 0.7.4 puts the `force` flag **next to `component-id`** in the `controlComponent.json` payload, where the cloud **silently ignores it**. The flag is only honoured **inside the `actions` object**.

Measured against a JA-106K (firmware MD60421.2), arming one section with an open window, disarming between attempts:

| Payload | `control-errors` | Result |
|---|---|---|
| `force` next to `component-id` (what ships today) | `[{component-id: SEC-…, control-error: BYPASS-TIMED}]` | stays `DISARM` |
| `force` at the top level of the payload | same | stays `DISARM` |
| `bypass: true` next to `component-id` | same | stays `DISARM` |
| **`force` inside `actions`** | **none** | **section arms** |

So the option was never broken in this integration; the request simply never carried the flag anywhere the cloud reads it.

## What this changes

`JablotronClient.control_section()` now builds the section control payload itself instead of calling `bridge.control_section()`, and follows the same two steps as the official MyJablotron app:

1. Request the state normally. If every detector is closed this is the only request, so a clean arm still costs exactly one call.
2. If the cloud answers with a bypass error **and** bypassing is enabled, repeat the request with the bypass confirmed.

If bypassing is disabled the response is handed to jablotronpy unchanged, so `WRONG-CODE` and every other control error raise exactly the same exceptions as before. The private jablotronpy helpers are reused deliberately so PIN fallback, session handling and error mapping stay identical; only the payload layout differs.

Because the retry is conditional, a bypass is now a discrete, observable event rather than something that silently happens on every arm.

## New: bypass reporting

`control_section()` returns a `JablotronSectionControlResult` (`success`, `bypassed`, `control_error`) instead of a bare `bool`. When a bypass was needed the alarm panel fires:

* `binary_sensor` **bypass indicator per controllable section** — turns `on` for 30 s then clears itself, with attributes `section_name`, `section_id`, `control_error`, `bypassed_at` that remain readable after it clears. Good for driving a notification or a dashboard pop-up.
* Bus event **`jablotron_cloud_section_bypassed`** with `service_id`, `service_name`, `section_id`, `section_name`, `control_error`.

This is the closest equivalent to the confirmation dialog the official app shows, given the constraint below.

## Known limitation: the detector cannot be named

The cloud identifies only the **section** in its bypass error, and there is no way to resolve the detector. Probed on this panel:

* `peripheralsGet`, `devicesGet`, `deviceStatesGet`, `componentsGet`, `activeDevicesGet`, `bypassedDevicesGet`, `diagnosticsGet`, `devicesStateGet`, `peripheralsStateGet`, `sectionDevicesGet`, `deviceListGet` -> `404 FUNCTION.NOT-FOUND`
* `eventHistoryGet` -> `400 METHOD.NOT-SUPPORTED` (consistent with the existing README caveat)
* `getServiceSettings` -> `wrong_service_type`

The mobile API exposes sections, PGs, thermo devices and keyboard segments and nothing below them. The README documents this explicitly and shows how to correlate the section with the user's own contact sensors instead, so nobody re-investigates it.

## Testing

Verified end to end on a live JA-106K with two controllable sections:

* Arm with an open window -> succeeds; bypass sensor `on` at `20:18:13` carrying `control_error: BYPASS-TIMED`, `off` at `20:18:43` (exactly 30 s), attributes retained.
* Arm with everything closed -> succeeds; bypass sensor stays `off` with no attributes, i.e. no false positives, and only one request is sent.
* Disarm -> unchanged.
* No errors in the HA log across two restarts.

## Notes for review

* **The real bug is in JablotronPy.** This PR works around it in the integration so users get a fix without waiting on a library release. Happy to open the upstream PR too and reduce this to a plain `bridge.control_section()` call once it lands.
* `ruff format` is clean. `ruff check custom_components/` reports **10** `PLR0917` errors vs **9** on current `main` — the one added is `JablotronSectionBypass.__init__`, whose signature deliberately mirrors the four existing entity constructors that already trip the same rule.
* The new entity uses `_attr_icon` and a composed `_attr_name`, matching current repo practice (`f"{section_name}_state"` etc.). Moving it to `icons.json` / a `translation_key` would be the tidier route per `CLAUDE.md`, but the repo has no `icons.json` and no entity-name translations yet, so that felt like your call rather than something to introduce here.
* `manifest.json` is bumped to `0.10.0`; drop that commit if you handle versioning at release time.
